### PR TITLE
Recognize the "required" keyword for dictionary members.

### DIFF
--- a/test.py
+++ b/test.py
@@ -211,6 +211,7 @@ typedef (short or sequence<(DOMString[]?[] or short)>? or DOMString[]?[]) sequen
 [foo] partial dictionary FooDict:BarDict {
     [one "]" ( tricky ] test)] short bar;
     [two] sequence<(double or Foo)> foo = "hello";
+    required Foo baz;
 }
 
 callback callFoo = short();

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -537,11 +537,12 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
         return output + ']]'
 
 
-class DictionaryMember(Construct): # [ExtendedAttributes] Type identifier [Default] ";"
+class DictionaryMember(Construct): # [ExtendedAttributes] ["required"] Type identifier [Default] ";"
     @classmethod
     def peek(cls, tokens):
         tokens.pushPosition(False)
         Construct.peek(tokens)
+        Symbol.peek(tokens, 'required')
         if (Type.peek(tokens)):
             token = tokens.peek()
             if (token and token.isIdentifier()):
@@ -551,6 +552,7 @@ class DictionaryMember(Construct): # [ExtendedAttributes] Type identifier [Defau
     
     def __init__(self, tokens, parent = None):
         Construct.__init__(self, tokens, parent)
+        self.required = Symbol(tokens, 'required') if (Symbol.peek(tokens, 'required')) else None
         self.type = Type(tokens)
         self.name = tokens.next().text
         self.default = Default(tokens) if (Default.peek(tokens)) else None
@@ -566,6 +568,8 @@ class DictionaryMember(Construct): # [ExtendedAttributes] Type identifier [Defau
         return output + (unicode(self.default) if (self.default) else '')
     
     def _markup(self, generator):
+        if (self.required):
+            self.required.markup(generator)
         generator.addType(self.type)
         generator.addName(self.name)
         if (self.default):
@@ -573,8 +577,14 @@ class DictionaryMember(Construct): # [ExtendedAttributes] Type identifier [Defau
         return self
 
     def __repr__(self):
-        output = '[dict-member: ' + Construct.__repr__(self) + repr(self.type) + ' [name: ' + self.name.encode('ascii', 'replace') + ']'
-        return output + ((' = [default: ' + repr(self.default) + ']]') if (self.default) else ']')
+        output = '[dict-member: ' + Construct.__repr__(self)
+        output += '[required] ' if (self.required) else ''
+        output += repr(self.type)
+        output += ' [name: ' + self.name.encode('ascii', 'replace') + ']'
+        if (self.default)
+            output += ' = [default: ' + repr(self.default) + ']'
+        output += ']'
+        return output
 
 
 class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" identifier [Inheritance] "{" [DictionaryMember]... "}" ";"


### PR DESCRIPTION
The WebIDL specification defines a concept of required dictionary
members, which have the "required" keyword prepending their type.

http://heycam.github.io/webidl/#required-dictionary-member

I ran into this when converting the Notification specification to use Bikeshed, which in turn uses the widlparser.

I'm not sure how to judge the test output. There are no (new) syntax error messages, and the complexity goes up by one. Is that sufficient?