### PR TITLE
Fix `required` AttributeNameKeyword

### DIFF
--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1118,12 +1118,7 @@ class AttributeRest(Production):   # ["readonly"] "attribute" Type ("required" |
         self.readonly = Symbol(tokens, 'readonly') if (Symbol.peek(tokens, 'readonly')) else None
         self._attribute = Symbol(tokens, 'attribute')
         self.type = Type(tokens)
-        if (Symbol.peek(tokens, 'required')):
-            self.required = Symbol(tokens, 'required')
-            self.name = None
-        else:
-            self.name = tokens.next().text
-            self.required = None
+        self.name = tokens.next().text
         self._ignore = Ignore(tokens) if (Ignore.peek(tokens)) else None
         self._consumeSemicolon(tokens)
         self._didParse(tokens)
@@ -1131,7 +1126,7 @@ class AttributeRest(Production):   # ["readonly"] "attribute" Type ("required" |
     def _unicode(self):
         output = unicode(self.readonly) if (self.readonly) else ''
         output += unicode(self._attribute) + unicode(self.type)
-        output += unicode(self.required) if (self.required) else self.name
+        output += self.name
         return output + (unicode(self._ignore) if (self._ignore) else '')
 
     def _markup(self, generator):
@@ -1139,10 +1134,7 @@ class AttributeRest(Production):   # ["readonly"] "attribute" Type ("required" |
             self.readonly.markup(generator)
         self._attribute.markup(generator)
         generator.addType(self.type)
-        if (self.required):
-            self.required.markup(generator)
-        else:
-            generator.addName(self.name)
+        generator.addName(self.name)
         if (self._ignore):
             self._ignore.markup(generator)
         return self
@@ -1151,7 +1143,7 @@ class AttributeRest(Production):   # ["readonly"] "attribute" Type ("required" |
         output = '[AttributeRest: '
         output += '[readonly] ' if (self.readonly) else ''
         output += repr(self.type)
-        output += ' [required]' if (self.required) else ' [name: ' + self.name + ']'
+        output += ' [name: ' + self.name + ']'
         return output + ']'
 
 


### PR DESCRIPTION
The `required` name in an attribute is just an identifier. It just happens to also be a reserved word so it needs some special handling. I have corrected the handling to pass the `required` name through as an identifier and removed the attribute handling that was there where it assumed it could have a `required` keyword associated with an identifier to make the particular attribute required.

Fixes #13 