### PR TITLE
Add Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,50 @@
-*.xcodeproj
-*.DS_Store
-local/*
+# Misc.
 *.log
-*.pyc
 *.orig
 .hg/*
+*.DS_Store
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+local
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+MANIFEST
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# IDE Files
+.mr.developer.cfg
+.project
+.pydevproject
+*.xcodeproj
+
+# Virtual environments
+venv
+
+# Documentation
+docs/_build

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,21 @@
 
 from distutils.core import setup
 
-setup(name='widlparser',
-      version='0.9994',
-      description='WebIDL Parser',
-      author='Peter Linss',
-      author_email='peter@linss.com',
-      url='http://github.com/plinss/widlparser/',
-      packages = ['widlparser']
-     )
+with open('README.md') as f:
+    readme = f.read()
+
+setup(
+    name='widlparser',
+    version=widlparser.__version__,
+    description=widlparser.__doc__,
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    author=widlparser.__author__[0],
+    author_email=widlparser.__email__[0],
+    maintainer=widlparser.__maintainer__,
+    maintainer_email=widlparser.__email__[1],
+    platforms=['any'],
+    url=widlparser.__url__,
+    packages=['widlparser'],
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+import widlparser
+from setuptools import setup
 
 with open('README.md') as f:
     readme = f.read()

--- a/test.py
+++ b/test.py
@@ -122,7 +122,7 @@ def test_difference(input, output):
         input_lines = input.split('\n')
         output_lines = output.split('\n')
 
-        for input_line, output_line in itertools.izip_longest(input_lines, output_lines, fillvalue=''):
+        for input_line, output_line in itertools.zip_longest(input_lines, output_lines, fillvalue=''):
             if (input_line != output_line):
                 print("<" + input_line)
                 print(">" + output_line)
@@ -140,7 +140,7 @@ if __name__ == "__main__":      # called from the command line
             parser.reset()
             text = file.read()
             parser.parse(text)
-            assert (text == unicode(parser))
+            assert (text == str(parser))
         quit()
 
 
@@ -331,8 +331,8 @@ interface mixin MixinCanNotIncludeSetlike {
     parser.parse(idl)
     print(repr(parser))
 
-    test_difference(idl, unicode(parser))
-    assert(unicode(parser) == idl)
+    test_difference(idl, str(parser))
+    assert(str(parser) == idl)
 
     print("MARKED UP:")
     marker = NullMarker()
@@ -340,13 +340,13 @@ interface mixin MixinCanNotIncludeSetlike {
     assert(marker.text == idl)
     print(parser.markup(Marker()))
 
-    print("Complexity: " + unicode(parser.complexityFactor))
+    print("Complexity: " + str(parser.complexityFactor))
 
 
     for construct in parser.constructs:
-        print(unicode(construct.idlType) + u': ' + unicode(construct.normalName))
+        print(str(construct.idlType) + u': ' + str(construct.normalName))
         for member in construct:
-            print('    ' + member.idlType + ': ' + unicode(member.normalName) + ' (' + unicode(member.name) + ')')
+            print('    ' + member.idlType + ': ' + str(member.normalName) + ' (' + str(member.name) + ')')
 
     print("FIND:")
     print(parser.find('round').fullName)

--- a/widlparser/__init__.py
+++ b/widlparser/__init__.py
@@ -10,6 +10,16 @@
 #  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231 
 #
 
-__all__ = ['parser', 'tokenizer', 'constructs', 'productions']
+__name__ = 'widlparser'
+__doc__ = 'WebIDL Parser'
+__author__ = ['Peter Linss', 'Vinyl Darkscratch']
+__version__ = '0.995'
+__license__ = 'https://opensource.org/licenses/W3C'
+__maintainer__ = 'Peter Linss'
+__email__ = ['peter@linss.com', 'vinyldarkscratch@gooborg.com']
+__status__ = 'Alpha'
+__url__ = 'http://github.com/plinss/widlparser/'
+
+__all__ = ['parser', 'tokenizer', 'constructs', 'productions', 'markup']
 
 import parser

--- a/widlparser/__init__.py
+++ b/widlparser/__init__.py
@@ -22,4 +22,4 @@ __url__ = 'http://github.com/plinss/widlparser/'
 
 __all__ = ['parser', 'tokenizer', 'constructs', 'productions', 'markup']
 
-import parser
+from . import parser

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -10,8 +10,8 @@
 #  [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 
-from productions import *
-from markup import MarkupGenerator
+from .productions import *
+from .markup import MarkupGenerator
 
 class Construct(ChildProduction):
     @classmethod
@@ -43,7 +43,7 @@ class Construct(ChildProduction):
     def extendedAttributes(self):
         return self._extendedAttributes if (self._extendedAttributes) else {}
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
 
     def __len__(self):
@@ -84,14 +84,14 @@ class Construct(ChildProduction):
         return 1
 
     def _unicode(self):
-        return unicode(self._extendedAttributes) if (self._extendedAttributes) else ''
+        return str(self._extendedAttributes) if (self._extendedAttributes) else ''
 
     def __repr__(self):
         return repr(self._extendedAttributes) if (self._extendedAttributes) else ''
 
     def markup(self, generator):
         if (not generator):
-            return unicode(self)
+            return str(self)
 
         if (isinstance(generator, MarkupGenerator)):
             marker = None
@@ -105,8 +105,8 @@ class Construct(ChildProduction):
             self._extendedAttributes.markup(myGenerator)
         target = self._markup(myGenerator)
         if (target._tail):
-            myGenerator.addText(''.join([unicode(token) for token in target._tail]))
-        myGenerator.addText(unicode(target._semicolon))
+            myGenerator.addText(''.join([str(token) for token in target._tail]))
+        myGenerator.addText(str(target._semicolon))
 
         if (generator):
             generator.addGenerator(myGenerator)
@@ -134,7 +134,7 @@ class Const(Construct):    # "const" ConstType identifier "=" ConstValue ";"
         Construct.__init__(self, tokens, parent, False, parser = parser)
         self._const = Symbol(tokens, 'const')
         self.type = ConstType(tokens)
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._equals = Symbol(tokens, '=')
         self.value = ConstValue(tokens)
         self._consumeSemicolon(tokens)
@@ -157,7 +157,7 @@ class Const(Construct):    # "const" ConstType identifier "=" ConstValue ";"
         return 0
 
     def _unicode(self):
-        return unicode(self._const) + unicode(self.type) + self.name + unicode(self._equals) + unicode(self.value)
+        return str(self._const) + str(self.type) + self.name + str(self._equals) + str(self.value)
 
     def _markup(self, generator):
         self._const.markup(generator)
@@ -169,7 +169,7 @@ class Const(Construct):    # "const" ConstType identifier "=" ConstValue ";"
 
     def __repr__(self):
         return ('[const: ' + repr(self.type) +
-                '[name: ' + self.name + '] = [value: ' + unicode(self.value) + ']]')
+                '[name: ' + self.name + '] = [value: ' + str(self.value) + ']]')
 
 
 class Enum(Construct):    # [ExtendedAttributes] "enum" identifier "{" EnumValueList "}" ";"
@@ -191,7 +191,7 @@ class Enum(Construct):    # [ExtendedAttributes] "enum" identifier "{" EnumValue
     def __init__(self, tokens, parent = None, parser = None):
         Construct.__init__(self, tokens, parent, parser = parser)
         self._enum = Symbol(tokens, 'enum')
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._openBrace = Symbol(tokens, '{')
         self.values = EnumValueList(tokens)
         self._closeBrace = Symbol(tokens, '}')
@@ -204,7 +204,7 @@ class Enum(Construct):    # [ExtendedAttributes] "enum" identifier "{" EnumValue
         return 'enum'
 
     def _unicode(self):
-        return Construct._unicode(self) + unicode(self._enum) + self.name + unicode(self._openBrace) + unicode(self.values) + unicode(self._closeBrace)
+        return Construct._unicode(self) + str(self._enum) + self.name + str(self._openBrace) + str(self.values) + str(self._closeBrace)
 
     def _markup(self, generator):
         self._enum.markup(generator)
@@ -234,7 +234,7 @@ class Typedef(Construct):    # [ExtendedAttributes] "typedef" TypeWithExtendedAt
         Construct.__init__(self, tokens, parent, parser = parser)
         self._typedef = Symbol(tokens, 'typedef')
         self.type = TypeWithExtendedAttributes(tokens)
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._consumeSemicolon(tokens)
         self._didParse(tokens)
         self.parser.addType(self)
@@ -244,8 +244,8 @@ class Typedef(Construct):    # [ExtendedAttributes] "typedef" TypeWithExtendedAt
         return 'typedef'
 
     def _unicode(self):
-        output = Construct._unicode(self) + unicode(self._typedef)
-        return output + unicode(self.type) + unicode(self.name)
+        output = Construct._unicode(self) + str(self._typedef)
+        return output + str(self.type) + str(self.name)
 
     def _markup(self, generator):
         self._typedef.markup(generator)
@@ -309,11 +309,11 @@ class Argument(Construct):    # [ExtendedAttributeList] "optional" [IgnoreInOut]
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.optional) if (self.optional) else ''
-        output += unicode(self._ignore) if (self._ignore) else ''
-        output += unicode(self.type)
-        output += unicode(self.variadic) if (self.variadic) else ''
-        return output + unicode(self._name) + (unicode(self.default) if (self.default) else '')
+        output += str(self.optional) if (self.optional) else ''
+        output += str(self._ignore) if (self._ignore) else ''
+        output += str(self.type)
+        output += str(self.variadic) if (self.variadic) else ''
+        return output + str(self._name) + (str(self.default) if (self.default) else '')
 
     def _markup(self, generator):
         if (self.optional):
@@ -330,9 +330,9 @@ class Argument(Construct):    # [ExtendedAttributeList] "optional" [IgnoreInOut]
     def __repr__(self):
         output = '[argument: ' + Construct.__repr__(self)
         output += '[optional] ' if (self.optional) else ''
-        output += '[type: ' + unicode(self.type) + ']'
+        output += '[type: ' + str(self.type) + ']'
         output += '[...] ' if (self.variadic) else ' '
-        output += '[name: ' + unicode(self.name) + ']'
+        output += '[name: ' + str(self.name) + ']'
         return output + ((' [default: ' + repr(self.default) + ']]') if (self.default) else ']')
 
 
@@ -411,7 +411,7 @@ class InterfaceMember(Construct): # [ExtendedAttributes] Const | Operation | Spe
         return (not argumentNames)
 
     def _unicode(self):
-        return Construct._unicode(self) + unicode(self.member)
+        return Construct._unicode(self) + str(self.member)
 
     def _markup(self, generator):
         return self.member._markup(generator)
@@ -483,7 +483,7 @@ class MixinMember(Construct): # [ExtendedAttributes] Const | Operation | Stringi
         return (not argumentNames)
 
     def _unicode(self):
-        return Construct._unicode(self) + unicode(self.member)
+        return Construct._unicode(self) + str(self.member)
 
     def _markup(self, generator):
         return self.member._markup(generator)
@@ -515,7 +515,7 @@ class SyntaxError(Construct):   # ... ";" | ... "}"
         return False
 
     def _unicode(self):
-        return ''.join([unicode(token) for token in self.tokens])
+        return ''.join([str(token) for token in self.tokens])
 
     def __repr__(self):
         output = '[unknown: ' + Construct.__repr__(self) + ' tokens: '
@@ -540,7 +540,7 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
         Construct.__init__(self, tokens, parent, (not parent), parser = parser)
         self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
         self._interface = Symbol(tokens, 'interface')
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self.inheritance = Inheritance(tokens) if (Inheritance.peek(tokens)) else None
         self._openBrace = Symbol(tokens, '{')
         self.members = self.constructors
@@ -572,7 +572,7 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
         return [member.name for member in self.members]
 
     def __getitem__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return member
@@ -583,7 +583,7 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
         return iter(self.members)
 
     def __contains__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return True
@@ -627,14 +627,14 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.partial) if (self.partial) else ''
-        output += unicode(self._interface) + self.name
-        output += unicode(self.inheritance) if (self.inheritance) else ''
-        output += unicode(self._openBrace)
+        output += str(self.partial) if (self.partial) else ''
+        output += str(self._interface) + self.name
+        output += str(self.inheritance) if (self.inheritance) else ''
+        output += str(self._openBrace)
         for member in self.members:
             if ('constructor' != member.idlType):
-                output += unicode(member)
-        return output + unicode(self._closeBrace) if (self._closeBrace) else output
+                output += str(member)
+        return output + str(self._closeBrace) if (self._closeBrace) else output
 
     def _markup(self, generator):
         if (self.partial):
@@ -653,7 +653,7 @@ class Interface(Construct):    # [ExtendedAttributes] ["partial"] "interface" id
     def __repr__(self):
         output = '[interface: ' + Construct.__repr__(self)
         output += '[partial] ' if (self.partial) else ''
-        output += '[name: ' + self.name.encode('ascii', 'replace') + '] '
+        output += '[name: ' + self.name + '] '
         output += repr(self.inheritance) if (self.inheritance) else ''
         output += '[members: \n'
         for member in self.members:
@@ -680,7 +680,7 @@ class Mixin(Construct):    # [ExtendedAttributes] ["partial"] "interface" "mixin
         self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
         self._interface = Symbol(tokens, 'interface')
         self._mixin = Symbol(tokens, 'mixin')
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self.inheritance = Inheritance(tokens) if (Inheritance.peek(tokens)) else None
         self._openBrace = Symbol(tokens, '{')
         self.members = self.constructors
@@ -712,7 +712,7 @@ class Mixin(Construct):    # [ExtendedAttributes] ["partial"] "interface" "mixin
         return [member.name for member in self.members]
 
     def __getitem__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return member
@@ -723,7 +723,7 @@ class Mixin(Construct):    # [ExtendedAttributes] ["partial"] "interface" "mixin
         return iter(self.members)
 
     def __contains__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return True
@@ -767,14 +767,14 @@ class Mixin(Construct):    # [ExtendedAttributes] ["partial"] "interface" "mixin
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.partial) if (self.partial) else ''
-        output += unicode(self._interface) + unicode(self._mixin) + self.name
-        output += unicode(self.inheritance) if (self.inheritance) else ''
-        output += unicode(self._openBrace)
+        output += str(self.partial) if (self.partial) else ''
+        output += str(self._interface) + str(self._mixin) + self.name
+        output += str(self.inheritance) if (self.inheritance) else ''
+        output += str(self._openBrace)
         for member in self.members:
             if ('constructor' != member.idlType):
-                output += unicode(member)
-        return output + unicode(self._closeBrace) if (self._closeBrace) else output
+                output += str(member)
+        return output + str(self._closeBrace) if (self._closeBrace) else output
 
     def _markup(self, generator):
         if (self.partial):
@@ -795,7 +795,7 @@ class Mixin(Construct):    # [ExtendedAttributes] ["partial"] "interface" "mixin
         output = '[interface: ' + Construct.__repr__(self)
         output += '[partial] ' if (self.partial) else ''
         output += '[mixin] '
-        output += '[name: ' + self.name.encode('ascii', 'replace') + '] '
+        output += '[name: ' + self.name + '] '
         output += repr(self.inheritance) if (self.inheritance) else ''
         output += '[members: \n'
         for member in self.members:
@@ -863,7 +863,7 @@ class NamespaceMember(Construct): # [ExtendedAttributes] Operation | "readonly" 
         return (not argumentNames)
 
     def _unicode(self):
-        return Construct._unicode(self) + unicode(self.member)
+        return Construct._unicode(self) + str(self.member)
 
     def _markup(self, generator):
         return self.member._markup(generator)
@@ -891,7 +891,7 @@ class Namespace(Construct):    # [ExtendedAttributes] ["partial"] "namespace" id
         Construct.__init__(self, tokens, parent, (not parent), parser = parser)
         self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
         self._namespace = Symbol(tokens, 'namespace')
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._openBrace = Symbol(tokens, '{')
         self.members = []
         self._closeBrace = None
@@ -922,7 +922,7 @@ class Namespace(Construct):    # [ExtendedAttributes] ["partial"] "namespace" id
         return [member.name for member in self.members]
 
     def __getitem__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return member
@@ -933,7 +933,7 @@ class Namespace(Construct):    # [ExtendedAttributes] ["partial"] "namespace" id
         return iter(self.members)
 
     def __contains__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return True
@@ -977,12 +977,12 @@ class Namespace(Construct):    # [ExtendedAttributes] ["partial"] "namespace" id
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.partial) if (self.partial) else ''
-        output += unicode(self._namespace) + self.name
-        output += unicode(self._openBrace)
+        output += str(self.partial) if (self.partial) else ''
+        output += str(self._namespace) + self.name
+        output += str(self._openBrace)
         for member in self.members:
-            output += unicode(member)
-        return output + unicode(self._closeBrace) if (self._closeBrace) else output
+            output += str(member)
+        return output + str(self._closeBrace) if (self._closeBrace) else output
 
     def _markup(self, generator):
         if (self.partial):
@@ -998,7 +998,7 @@ class Namespace(Construct):    # [ExtendedAttributes] ["partial"] "namespace" id
     def __repr__(self):
         output = '[namespace: ' + Construct.__repr__(self)
         output += '[partial] ' if (self.partial) else ''
-        output += '[name: ' + self.name.encode('ascii', 'replace') + '] '
+        output += '[name: ' + self.name + '] '
         output += '[members: \n'
         for member in self.members:
             output += '  ' + repr(member) + '\n'
@@ -1022,7 +1022,7 @@ class DictionaryMember(Construct): # [ExtendedAttributes] ["required"] TypeWithE
         Construct.__init__(self, tokens, parent)
         self.required = Symbol(tokens, 'required') if (Symbol.peek(tokens, 'required')) else None
         self.type = TypeWithExtendedAttributes(tokens)
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self.default = Default(tokens) if (Default.peek(tokens)) else None
         self._consumeSemicolon(tokens)
         self._didParse(tokens)
@@ -1033,9 +1033,9 @@ class DictionaryMember(Construct): # [ExtendedAttributes] ["required"] TypeWithE
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.required) if (self.required) else ''
-        output += unicode(self.type) + unicode(self.name)
-        return output + (unicode(self.default) if (self.default) else '')
+        output += str(self.required) if (self.required) else ''
+        output += str(self.type) + str(self.name)
+        return output + (str(self.default) if (self.default) else '')
 
     def _markup(self, generator):
         if (self.required):
@@ -1050,7 +1050,7 @@ class DictionaryMember(Construct): # [ExtendedAttributes] ["required"] TypeWithE
         output = '[dict-member: ' + Construct.__repr__(self)
         output += '[required] ' if (self.required) else ''
         output += repr(self.type)
-        output += ' [name: ' + self.name.encode('ascii', 'replace') + ']'
+        output += ' [name: ' + self.name + ']'
         if (self.default):
             output += ' = [default: ' + repr(self.default) + ']'
         output += ']'
@@ -1074,7 +1074,7 @@ class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" id
         Construct.__init__(self, tokens, parent, parser = parser)
         self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
         self._dictionary = Symbol(tokens, 'dictionary')
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self.inheritance = Inheritance(tokens) if (Inheritance.peek(tokens)) else None
         self._openBrace = Symbol(tokens, '{')
         self.members = []
@@ -1113,7 +1113,7 @@ class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" id
         return [member.name for member in self.members]
 
     def __getitem__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return member
@@ -1124,7 +1124,7 @@ class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" id
         return iter(self.members)
 
     def __contains__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for member in self.members:
                 if (key == member.name):
                     return True
@@ -1142,13 +1142,13 @@ class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" id
 
     def _unicode(self):
         output = Construct._unicode(self)
-        output += unicode(self.partial) if (self.partial) else ''
-        output += unicode(self._dictionary) + self.name
-        output += unicode(self.inheritance) if (self.inheritance) else ''
-        output += unicode(self._openBrace)
+        output += str(self.partial) if (self.partial) else ''
+        output += str(self._dictionary) + self.name
+        output += str(self.inheritance) if (self.inheritance) else ''
+        output += str(self._openBrace)
         for member in self.members:
-            output += unicode(member)
-        return output + unicode(self._closeBrace) if (self._closeBrace) else output
+            output += str(member)
+        return output + str(self._closeBrace) if (self._closeBrace) else output
 
     def _markup(self, generator):
         if (self.partial):
@@ -1166,7 +1166,7 @@ class Dictionary(Construct):  # [ExtendedAttributes] ["partial"] "dictionary" id
     def __repr__(self):
         output = '[dictionary: ' + Construct.__repr__(self)
         output += '[partial] ' if (self.partial) else ''
-        output += '[name: ' + self.name.encode('ascii', 'replace') + '] '
+        output += '[name: ' + self.name + '] '
         output += repr(self.inheritance) if (self.inheritance) else ''
         output += '[members: \n'
         for member in self.members:
@@ -1201,7 +1201,7 @@ class Callback(Construct):    # [ExtendedAttributes] "callback" identifier "=" R
         self._callback = Symbol(tokens, 'callback')
         token = tokens.sneakPeek()
         if (token.isIdentifier()):
-            self.name = tokens.next().text
+            self.name = tokens.nextToken().text
             self._equals = Symbol(tokens, '=')
             self.returnType = ReturnType(tokens)
             self._openParen = Symbol(tokens, '(')
@@ -1239,7 +1239,7 @@ class Callback(Construct):    # [ExtendedAttributes] "callback" identifier "=" R
 
     def __getitem__(self, key):
         if (self.interface):
-            if (isinstance(key, basestring)):
+            if (isinstance(key, str)):
                 for member in self.interface.members:
                     if (key == member.name):
                         return member
@@ -1254,7 +1254,7 @@ class Callback(Construct):    # [ExtendedAttributes] "callback" identifier "=" R
 
     def __contains__(self, key):
         if (self.interface):
-            if (isinstance(key, basestring)):
+            if (isinstance(key, str)):
                 for member in self.interface.members:
                     if (key == member.name):
                         return True
@@ -1296,11 +1296,11 @@ class Callback(Construct):    # [ExtendedAttributes] "callback" identifier "=" R
         return result
 
     def _unicode(self):
-        output = Construct._unicode(self) + unicode(self._callback)
+        output = Construct._unicode(self) + str(self._callback)
         if (self.interface):
-            return output + unicode(self.interface)
-        output += self.name + unicode(self._equals) + unicode(self.returnType)
-        return output + unicode(self._openParen) + (unicode(self.arguments) if (self.arguments) else '') + unicode(self._closeParen)
+            return output + str(self.interface)
+        output += self.name + str(self._equals) + str(self.returnType)
+        return output + str(self._openParen) + (str(self.arguments) if (self.arguments) else '') + str(self._closeParen)
 
     def _markup(self, generator):
         self._callback.markup(generator)
@@ -1319,7 +1319,7 @@ class Callback(Construct):    # [ExtendedAttributes] "callback" identifier "=" R
         output = '[callback: ' + Construct.__repr__(self)
         if (self.interface):
             return output + repr(self.interface) + ']'
-        output += '[name: ' + self.name.encode('ascii', 'replace') + '] [returnType: ' + unicode(self.returnType) + '] '
+        output += '[name: ' + self.name + '] [returnType: ' + str(self.returnType) + '] '
         return output + '[argumentlist: ' + (repr(self.arguments) if (self.arguments) else '') + ']]'
 
 
@@ -1337,9 +1337,9 @@ class ImplementsStatement(Construct):  # [ExtendedAttributes] identifier "implem
 
     def __init__(self, tokens, parent = None, parser = None):
         Construct.__init__(self, tokens, parent, parser = parser)
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._implements = Symbol(tokens, 'implements')
-        self.implements = tokens.next().text
+        self.implements = tokens.nextToken().text
         self._consumeSemicolon(tokens)
         self._didParse(tokens)
 
@@ -1348,7 +1348,7 @@ class ImplementsStatement(Construct):  # [ExtendedAttributes] identifier "implem
         return 'implements'
 
     def _unicode(self):
-        return Construct._unicode(self) + self.name + unicode(self._implements) + self.implements
+        return Construct._unicode(self) + self.name + str(self._implements) + self.implements
 
     def _markup(self, generator):
         generator.addTypeName(self.name)
@@ -1357,7 +1357,7 @@ class ImplementsStatement(Construct):  # [ExtendedAttributes] identifier "implem
         return self
 
     def __repr__(self):
-        return '[implements: ' + Construct.__repr__(self) + '[name: ' + self.name.encode('ascii', 'replace') + '] [implements: ' + self.implements + ']]'
+        return '[implements: ' + Construct.__repr__(self) + '[name: ' + self.name + '] [implements: ' + self.implements + ']]'
 
 
 class IncludesStatement(Construct):  # identifier "includes" identifier ";"
@@ -1373,9 +1373,9 @@ class IncludesStatement(Construct):  # identifier "includes" identifier ";"
 
     def __init__(self, tokens, parent = None, parser = None):
         Construct.__init__(self, tokens, parent, parser = parser)
-        self.name = tokens.next().text
+        self.name = tokens.nextToken().text
         self._includes = Symbol(tokens, 'includes')
-        self.includes = tokens.next().text
+        self.includes = tokens.nextToken().text
         self._consumeSemicolon(tokens)
         self._didParse(tokens)
 
@@ -1384,7 +1384,7 @@ class IncludesStatement(Construct):  # identifier "includes" identifier ";"
         return 'includes'
 
     def _unicode(self):
-        return Construct._unicode(self) + self.name + unicode(self._includes) + self.includes
+        return Construct._unicode(self) + self.name + str(self._includes) + self.includes
 
     def _markup(self, generator):
         generator.addTypeName(self.name)
@@ -1393,7 +1393,7 @@ class IncludesStatement(Construct):  # identifier "includes" identifier ";"
         return self
 
     def __repr__(self):
-        return '[includes: ' + Construct.__repr__(self) + '[name: ' + self.name.encode('ascii', 'replace') + '] [includes: ' + self.includes + ']]'
+        return '[includes: ' + Construct.__repr__(self) + '[name: ' + self.name + '] [includes: ' + self.includes + ']]'
 
 
 class ExtendedAttributeUnknown(Construct): # list of tokens
@@ -1413,7 +1413,7 @@ class ExtendedAttributeUnknown(Construct): # list of tokens
         return None
 
     def _unicode(self):
-        return ''.join([unicode(token) for token in self.tokens])
+        return ''.join([str(token) for token in self.tokens])
 
     def __repr__(self):
         return '[ExtendedAttribute: ' + ''.join([repr(token) for token in self.tokens]) + ']'
@@ -1430,7 +1430,7 @@ class ExtendedAttributeNoArgs(Construct):   # identifier
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._didParse(tokens)
 
     @property
@@ -1453,7 +1453,7 @@ class ExtendedAttributeNoArgs(Construct):   # identifier
         return self
 
     def __repr__(self):
-        return '[ExtendedAttributeNoArgs: ' + self.attribute.encode('ascii', 'replace') + ']'
+        return '[ExtendedAttributeNoArgs: ' + self.attribute + ']'
 
 
 class ExtendedAttributeArgList(Construct):  # identifier "(" [ArgumentList] ")"
@@ -1470,7 +1470,7 @@ class ExtendedAttributeArgList(Construct):  # identifier "(" [ArgumentList] ")"
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._openParen = Symbol(tokens, '(')
         self.arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
         self._closeParen = Symbol(tokens, ')')
@@ -1491,7 +1491,7 @@ class ExtendedAttributeArgList(Construct):  # identifier "(" [ArgumentList] ")"
         return self.attribute
 
     def _unicode(self):
-        return self.attribute + unicode(self._openParen) + (unicode(self.arguments) if (self.arguments) else '') + unicode(self._closeParen)
+        return self.attribute + str(self._openParen) + (str(self.arguments) if (self.arguments) else '') + str(self._closeParen)
 
     def _markup(self, generator):
         generator.addName(self.attribute)
@@ -1502,7 +1502,7 @@ class ExtendedAttributeArgList(Construct):  # identifier "(" [ArgumentList] ")"
         return self
 
     def __repr__(self):
-        return ('[ExtendedAttributeArgList: ' + self.attribute.encode('ascii', 'replace') +
+        return ('[ExtendedAttributeArgList: ' + self.attribute +
                 ' [arguments: ' + (repr(self.arguments) if (self.arguments) else '') + ']]')
 
 
@@ -1520,9 +1520,9 @@ class ExtendedAttributeIdent(Construct):    # identifier "=" identifier
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._equals = Symbol(tokens, '=')
-        self.value = tokens.next().text
+        self.value = tokens.nextToken().text
         self._didParse(tokens)
 
     @property
@@ -1538,7 +1538,7 @@ class ExtendedAttributeIdent(Construct):    # identifier "=" identifier
         return (self.value + '()') if ('constructor' == self.idlType) else self.attribute
 
     def _unicode(self):
-        return self.attribute + unicode(self._equals) + self.value
+        return self.attribute + str(self._equals) + self.value
 
     def _markup(self, generator):
         generator.addName(self.attribute)
@@ -1547,7 +1547,7 @@ class ExtendedAttributeIdent(Construct):    # identifier "=" identifier
         return self
 
     def __repr__(self):
-        return ('[ExtendedAttributeIdent: ' + self.attribute.encode('ascii', 'replace') + ' [value: ' + self.value + ']]')
+        return ('[ExtendedAttributeIdent: ' + self.attribute + ' [value: ' + self.value + ']]')
 
 
 class ExtendedAttributeIdentList(Construct):    # identifier "=" "(" identifier [Identifiers] ")"
@@ -1567,11 +1567,11 @@ class ExtendedAttributeIdentList(Construct):    # identifier "=" "(" identifier 
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._equals = Symbol(tokens, '=')
         self._openParen = Symbol(tokens, '(')
-        self.value = tokens.next().text
-        self.next = Identifiers(tokens) if (Identifiers.peek(tokens)) else None
+        self.value = tokens.nextToken().text
+        self.__next__ = Identifiers(tokens) if (Identifiers.peek(tokens)) else None
         self._closeParen = Symbol(tokens, ')')
         self._didParse(tokens)
 
@@ -1588,25 +1588,25 @@ class ExtendedAttributeIdentList(Construct):    # identifier "=" "(" identifier 
         return (self.value + '()') if ('constructor' == self.idlType) else self.attribute
 
     def _unicode(self):
-        return (self.attribute + unicode(self._equals) + unicode(self._openParen) + self.value +
-                (unicode(self.next) if (self.next) else '') + unicode(self._closeParen))
+        return (self.attribute + str(self._equals) + str(self._openParen) + self.value +
+                (str(self.__next__) if (self.__next__) else '') + str(self._closeParen))
 
     def _markup(self, generator):
         generator.addName(self.attribute)
         generator.addText(self._equals)
         generator.addText(self._openParen)
         generator.addTypeName(self.value)
-        next = self.next
+        next = self.__next__
         while (next):
             generator.addText(next._comma)
             generator.addTypeName(next.name)
-            next = next.next
+            next = next.__next__
         generator.addText(self._closeParen)
         return self
 
     def __repr__(self):
-        return ('[ExtendedAttributeIdentList: ' + self.attribute.encode('ascii', 'replace') + ' [value: ' + self.value + ']' +
-                (repr(self.next) if (self.next) else '') + ']')
+        return ('[ExtendedAttributeIdentList: ' + self.attribute + ' [value: ' + self.value + ']' +
+                (repr(self.__next__) if (self.__next__) else '') + ']')
 
 
 class ExtendedAttributeNamedArgList(Construct): # identifier "=" identifier "(" [ArgumentList] ")"
@@ -1626,9 +1626,9 @@ class ExtendedAttributeNamedArgList(Construct): # identifier "=" identifier "(" 
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._equals = Symbol(tokens, '=')
-        self.value = tokens.next().text
+        self.value = tokens.nextToken().text
         self._openParen = Symbol(tokens, '(')
         self.arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
         self._closeParen = Symbol(tokens, ')')
@@ -1649,8 +1649,8 @@ class ExtendedAttributeNamedArgList(Construct): # identifier "=" identifier "(" 
         return self.attribute
 
     def _unicode(self):
-        output = self.attribute + unicode(self._equals) + self.value
-        return output + unicode(self._openParen) + (unicode(self.arguments) if (self.arguments) else '') + unicode(self._closeParen)
+        output = self.attribute + str(self._equals) + self.value
+        return output + str(self._openParen) + (str(self.arguments) if (self.arguments) else '') + str(self._closeParen)
 
     def _markup(self, generator):
         generator.addName(self.attribute)
@@ -1663,7 +1663,7 @@ class ExtendedAttributeNamedArgList(Construct): # identifier "=" identifier "(" 
         return self
 
     def __repr__(self):
-        return ('[ExtendedAttributeNamedArgList: ' + self.attribute.encode('ascii', 'replace') + ' [value: ' + self.value + ']' +
+        return ('[ExtendedAttributeNamedArgList: ' + self.attribute + ' [value: ' + self.value + ']' +
                 ' [arguments: ' + (repr(self.arguments) if (self.arguments) else '') + ']]')
 
 
@@ -1683,7 +1683,7 @@ class ExtendedAttributeTypePair(Construct): # identifier "(" Type "," Type ")"
 
     def __init__(self, tokens, parent):
         Construct.__init__(self, tokens, parent, False)
-        self.attribute = tokens.next().text
+        self.attribute = tokens.nextToken().text
         self._openParen = Symbol(tokens, '(')
         self.keyType = Type(tokens)
         self._comma = Symbol(tokens, ',')
@@ -1700,8 +1700,8 @@ class ExtendedAttributeTypePair(Construct): # identifier "(" Type "," Type ")"
         return self.attribute
 
     def _unicode(self):
-        output = self.attribute + unicode(self._openParen) + unicode(self.keyType) + unicode(self._comma)
-        return output + unicode(self.valueType) + unicode(self._closeParen)
+        output = self.attribute + str(self._openParen) + str(self.keyType) + str(self._comma)
+        return output + str(self.valueType) + str(self._closeParen)
 
     def _markup(self, generator):
         generator.addName(self.attribute)
@@ -1713,7 +1713,7 @@ class ExtendedAttributeTypePair(Construct): # identifier "(" Type "," Type ")"
         return self
 
     def __repr__(self):
-        return ('[ExtendedAttributeTypePair: ' + self.attribute.encode('ascii', 'replace') + ' ' +
+        return ('[ExtendedAttributeTypePair: ' + self.attribute + ' ' +
                 repr(self.keyType) + ' ' + repr(self.valueType) + ']')
 
 
@@ -1783,7 +1783,7 @@ class ExtendedAttribute(Construct): # ExtendedAttributeNoArgs | ExtendedAttribut
         return (not argumentNames)
 
     def _unicode(self):
-        return unicode(self.attribute)
+        return str(self.attribute)
 
     def _markup(self, generator):
         return self.attribute._markup(generator)

--- a/widlparser/markup.py
+++ b/widlparser/markup.py
@@ -62,13 +62,13 @@ class MarkupGenerator(object):
     def addText(self, text):
         if (text):
             if ((0 < len(self.children)) and (type(self.children[-1]) is MarkupText)):
-                self.children[-1].text += unicode(text)
+                self.children[-1].text += str(text)
             else:
-                self.children.append(MarkupText(unicode(text)))
+                self.children.append(MarkupText(str(text)))
 
     @property
     def text(self):
-        return u''.join([child.text for child in self.children])
+        return ''.join([child.text for child in self.children])
 
     def _markup(self, marker):
         if (self.construct and hasattr(marker, 'markupConstruct')):
@@ -77,9 +77,9 @@ class MarkupGenerator(object):
 
     def markup(self, marker, parent = None):
         head, tail = self._markup(marker)
-        output = unicode(head) if (head) else u''
-        output += u''.join([child.markup(marker, self.construct) for child in self.children])
-        return output + (unicode(tail) if (tail) else u'')
+        output = str(head) if (head) else ''
+        output += ''.join([child.markup(marker, self.construct) for child in self.children])
+        return output + (str(tail) if (tail) else '')
 
 
 class MarkupType(MarkupGenerator):
@@ -142,7 +142,7 @@ class MarkupText(object):
         self.text = text
 
     def markup(self, marker, construct):
-        return unicode(marker.encode(self.text)) if (hasattr(marker, 'encode')) else self.text
+        return str(marker.encode(self.text)) if (hasattr(marker, 'encode')) else self.text
 
 
 class MarkupTypeName(MarkupText):
@@ -151,9 +151,9 @@ class MarkupTypeName(MarkupText):
 
     def markup(self, marker, construct):
         head, tail = marker.markupTypeName(self.text, construct) if (hasattr(marker, 'markupTypeName')) else (None, None)
-        output = unicode(head) if (head) else u''
+        output = str(head) if (head) else ''
         output += MarkupText.markup(self, marker, construct)
-        return output + (unicode(tail) if (tail) else u'')
+        return output + (str(tail) if (tail) else '')
 
 
 class MarkupName(MarkupText):
@@ -162,9 +162,9 @@ class MarkupName(MarkupText):
 
     def markup(self, marker, construct):
         head, tail = marker.markupName(self.text, construct) if (hasattr(marker, 'markupName')) else (None, None)
-        output = unicode(head) if (head) else u''
+        output = str(head) if (head) else ''
         output += MarkupText.markup(self, marker, construct)
-        return output + (unicode(tail) if (tail) else u'')
+        return output + (str(tail) if (tail) else '')
 
 
 class MarkupKeyword(MarkupText):
@@ -173,9 +173,9 @@ class MarkupKeyword(MarkupText):
 
     def markup(self, marker, construct):
         head, tail = marker.markupKeyword(self.text, construct) if (hasattr(marker, 'markupKeyword')) else (None, None)
-        output = unicode(head) if (head) else u''
+        output = str(head) if (head) else ''
         output += MarkupText.markup(self, marker, construct)
-        return output + (unicode(tail) if (tail) else u'')
+        return output + (str(tail) if (tail) else '')
 
 
 class MarkupEnumValue(MarkupText):
@@ -184,7 +184,7 @@ class MarkupEnumValue(MarkupText):
 
     def markup(self, marker, construct):
         head, tail = marker.markupEnumValue(self.text, construct) if (hasattr(marker, 'markupEnumValue')) else (None, None)
-        output = unicode(head) if (head) else u''
+        output = str(head) if (head) else ''
         output += MarkupText.markup(self, marker, construct)
-        return output + (unicode(tail) if (tail) else u'')
+        return output + (str(tail) if (tail) else '')
 

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -13,8 +13,8 @@
 import re
 import itertools
 
-import tokenizer
-from constructs import *
+from . import tokenizer
+from .constructs import *
 
 
 class Parser(object):
@@ -63,10 +63,7 @@ class Parser(object):
                 self.constructs.append(SyntaxError(tokens, None, parser = self))
 
     def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
-        return u''.join([unicode(construct) for construct in self.constructs])
+        return ''.join([str(construct) for construct in self.constructs])
 
     def __repr__(self):
         return '[Parser: ' + ''.join([(repr(construct) + '\n') for construct in self.constructs]) + ']'
@@ -78,21 +75,21 @@ class Parser(object):
         return [construct.name for construct in self.constructs]
 
     def __getitem__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for construct in self.constructs:
                 if (key == construct.name):
                     return construct
             return None
         return self.constructs[key]
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
 
     def __iter__(self):
         return iter(self.constructs)
 
     def __contains__(self, key):
-        if (isinstance(key, basestring)):
+        if (isinstance(key, str)):
             for construct in self.constructs:
                 if (key == construct.name):
                     return True
@@ -278,6 +275,6 @@ class Parser(object):
             for construct in self.constructs:
                 construct.markup(generator)
             return generator.markup(marker)
-        return unicode(self)
+        return str(self)
 
 

--- a/widlparser/tokenizer.py
+++ b/widlparser/tokenizer.py
@@ -21,7 +21,7 @@ class Token(object):
     def isSymbol(self, symbol = None):
         if ('symbol' == self.type):
             if (symbol):
-                if isinstance(symbol, basestring):
+                if isinstance(symbol, str):
                     return (symbol == self.text)
                 return (self.text in symbol)
             return True
@@ -42,11 +42,11 @@ class Token(object):
     def isWhitespace(self):
         return ('whitespace' == self.type)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.text
 
     def __repr__(self):
-        return '[' + self.type + ':' + self.text.encode('ascii', 'replace') + ']'
+        return '[' + self.type + ':' + self.text + ']'
 
 
 
@@ -108,8 +108,8 @@ class Tokenizer(object):
             self.tokens.append(Token('other', match.group(1)))
             text = match.group(2)
 
-    def __unicode__(self):
-        return u''.join([unicode(token) for token in self.tokens])
+    def __str__(self):
+        return ''.join([str(token) for token in self.tokens])
 
     def __repr__(self):
         return ''.join([repr(token) for token in self.tokens])
@@ -122,7 +122,7 @@ class Tokenizer(object):
             return True
         return False
 
-    def next(self, skipWhitespace = True):
+    def nextToken(self, skipWhitespace = True):
         "Remove and return next available token, optionally skipping whitespace"
         self.resetPeek()
         if (0 < len(self.tokens)):
@@ -143,7 +143,7 @@ class Tokenizer(object):
 
     def whitespace(self):
         "Get next token only if it is whitespace"
-        token = self.next(False)
+        token = self.nextToken(False)
         if (token):
             if (token.isWhitespace()):
                 return token
@@ -202,7 +202,7 @@ class Tokenizer(object):
 
     def seekSymbol(self, symbol):
         "Return all tokens up to and inculding symbol, respect nesting of (), {}, []"
-        token = self.next(False)
+        token = self.nextToken(False)
         skipped = []
         while (token and (not token.isSymbol(symbol))):
             skipped.append(token)
@@ -212,7 +212,7 @@ class Tokenizer(object):
                 skipped += self.seekSymbol('}')
             elif (token.isSymbol('[')):
                 skipped += self.seekSymbol(']')
-            token = self.next(False)
+            token = self.nextToken(False)
         if (token):
             skipped.append(token)
         return skipped
@@ -222,7 +222,7 @@ class Tokenizer(object):
         lineNumber = self.lineNumber
         skipped = self.seekSymbol(symbol) if (symbol) else None
         if (self.ui and hasattr(self.ui, 'warn')):
-            message = u'IDL SYNTAX ERROR LINE: ' + unicode(lineNumber) + u' - '
+            message = 'IDL SYNTAX ERROR LINE: ' + str(lineNumber) + ' - '
             if (ending):
                 message += 'expected ";" '
 
@@ -232,7 +232,7 @@ class Tokenizer(object):
 
             if (symbol):
                 if (0 < len(skip)):
-                    self.ui.warn(message + u'skipped: "' + u''.join([unicode(token) for token in skip]) + '"\n')
+                    self.ui.warn(message + 'skipped: "' + ''.join([str(token) for token in skip]) + '"\n')
             else:
                 self.ui.warn(message + '\n')
         return skipped
@@ -240,12 +240,12 @@ class Tokenizer(object):
     def error(self, *args):
         "Report non-syntax error"
         if (self.ui and hasattr(self.ui, 'warn')):
-            message = u'IDL ERROR LINE: ' + unicode(self.lineNumber) + u' - ' + u''.join([unicode(arg) for arg in args])
+            message = 'IDL ERROR LINE: ' + str(self.lineNumber) + ' - ' + ''.join([str(arg) for arg in args])
             self.ui.warn(message + '\n')
 
     def didIgnore(self, ignored):
         "Report ignored content"
         if (self.ui and hasattr(self.ui, 'note')):
-            message = u'IGNORED LEGACY IDL LINE: ' + unicode(self.lineNumber) + u' - "'
-            ignoreText = u''.join(unicode(ignore) for ignore in ignored) if (hasattr(ignored, '__iter__')) else unicode(ignored)
+            message = 'IGNORED LEGACY IDL LINE: ' + str(self.lineNumber) + ' - "'
+            ignoreText = ''.join(str(ignore) for ignore in ignored) if (hasattr(ignored, '__iter__')) else str(ignored)
             self.ui.note(message + ignoreText + '"\n')


### PR DESCRIPTION
When first downloading and attempting to use this library, I noticed that it was written for Python 2, which has a [scheduled EOL of January 1, 2020](https://pythonclock.org/).  This pull request runs `2to3` and makes changes as needed to ensure proper support on Python 3 (one of which is renaming `Token.next` to `Token.nextToken`, and embedding Unicode support by default).  This also switches from `distutils.core` to `setuptools` as Python recommends using for proper support with `pip`.