### PR TITLE
Fix case of WebIDL biginit

### DIFF
--- a/test-expected.txt
+++ b/test-expected.txt
@@ -192,7 +192,7 @@ interface Underscores {
   boolean _includes(DOMString value);
 };
 interface BigNumbers {
-  const BigInt biiig = 42;
+  const bigint biiig = 42;
 };
 
 <<<
@@ -432,7 +432,7 @@ IDL SYNTAX ERROR LINE: 186 - skipped: "readonly setlike<DOMString>"
   [Member: [Operation: [Type: [SingleType: [NonAnyType: [PrimitiveType: boolean]]]] [OperationRest: [name: [OperationName: _includes]] [ArgumentList: [Argument: [type: DOMString ] [name: [ArgumentName: value]]]]]]]
 ]]
 [Interface: [name: BigNumbers] [members: 
-  [Member: [Const: [ConstType: [PrimitiveType: BigInt]][name: biiig] = [value: 42]]]
+  [Member: [Const: [ConstType: [PrimitiveType: bigint]][name: biiig] = [value: 42]]]
 ]]
 ]
 MARKED UP:
@@ -629,7 +629,7 @@ typedef   short    shorttype  = error this is;</c>
   <c method><t><p><k>boolean</k></p></t> <n>_includes</n>(<c argument><t><s><k>DOMString</k></s></t> <n>value</n></c>);</c>
 };</c>
 <c interface><k>interface</k> <n>BigNumbers</n> {
-  <c const><k>const</k> <t><p><k>BigInt</k></p></t> <n>biiig</n> = 42;</c>
+  <c const><k>const</k> <t><p><k>bigint</k></p></t> <n>biiig</n> = 42;</c>
 };</c>
 
 Complexity: 148

--- a/test.py
+++ b/test.py
@@ -337,7 +337,7 @@ interface Underscores {
   boolean _includes(DOMString value);
 };
 interface BigNumbers {
-  const BigInt biiig = 42;
+  const bigint biiig = 42;
 };
 """
 #    idl = idl.replace(' ', '  ')

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -399,14 +399,14 @@ class PrimitiveType(Production):
 	Primitive type production.
 
 	Syntax:
-	UnsignedIntegerType | UnrestrictedFloatType | "undefined" | "boolean" | "byte" | "octet" | "BigInt"
+	UnsignedIntegerType | UnrestrictedFloatType | "undefined" | "boolean" | "byte" | "octet" | "bigint"
 	"""
 
 	type: Union[UnsignedIntegerType, UnrestrictedFloatType, Symbol]
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
-		return (UnsignedIntegerType.peek(tokens) or UnrestrictedFloatType.peek(tokens) or Symbol.peek(tokens, ('undefined', 'boolean', 'byte', 'octet', 'BigInt')))
+		return (UnsignedIntegerType.peek(tokens) or UnrestrictedFloatType.peek(tokens) or Symbol.peek(tokens, ('undefined', 'boolean', 'byte', 'octet', 'bigint')))
 
 	def __init__(self, tokens: Tokenizer) -> None:
 		Production.__init__(self, tokens)

--- a/widlparser/tokenizer.py
+++ b/widlparser/tokenizer.py
@@ -101,7 +101,7 @@ class Tokenizer(object):
 	"""Consume a string and convert to tokens."""
 
 	SYMBOL_IDENTS = frozenset((
-		'any', 'async', 'attribute', 'ArrayBuffer', 'BigInt', 'boolean', 'byte', 'ByteString', 'callback', 'const', 'constructor', 'creator', 'DataView',
+		'any', 'async', 'attribute', 'ArrayBuffer', 'bigint', 'boolean', 'byte', 'ByteString', 'callback', 'const', 'constructor', 'creator', 'DataView',
 		'deleter', 'dictionary', 'DOMString', 'double', 'enum', 'Error', 'exception', 'false', 'float',
 		'Float32Array', 'Float64Array', 'FrozenArray', 'getter', 'implements', 'includes', 'Infinity', '-Infinity', 'inherit', 'Int8Array',
 		'Int16Array', 'Int32Array', 'interface', 'iterable', 'legacycaller', 'legacyiterable', 'long', 'maplike', 'mixin',


### PR DESCRIPTION
BigInt is the WebIDL Type name, not the name used in WebIDL fragments
see also https://github.com/w3c/webrtc-encoded-transform/pull/92