### PR TITLE
Remove "exception" from the identifier list

### DIFF
--- a/widlparser/tokenizer.py
+++ b/widlparser/tokenizer.py
@@ -102,7 +102,7 @@ class Tokenizer(object):
 
 	SYMBOL_IDENTS = frozenset((
 		'any', 'async', 'attribute', 'ArrayBuffer', 'bigint', 'boolean', 'byte', 'ByteString', 'callback', 'const', 'constructor', 'creator', 'DataView',
-		'deleter', 'dictionary', 'DOMString', 'double', 'enum', 'Error', 'exception', 'false', 'float',
+		'deleter', 'dictionary', 'DOMString', 'double', 'enum', 'Error', 'false', 'float',
 		'Float32Array', 'Float64Array', 'FrozenArray', 'getter', 'implements', 'includes', 'Infinity', '-Infinity', 'inherit', 'Int8Array',
 		'Int16Array', 'Int32Array', 'interface', 'iterable', 'legacycaller', 'legacyiterable', 'long', 'maplike', 'mixin',
 		'namespace', 'NaN', 'null', 'object', 'ObservableArray', 'octet', 'optional', 'or', 'partial', 'Promise', 'readonly', 'record', 'required',


### PR DESCRIPTION
This was preventing the use of it as a parameter name, but has no backing in the Web IDL spec.