### PR TITLE
Use TYPE_CHECKING to avoid circular refs and remove all the fake protocols

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,6 +14,7 @@
 import html
 import itertools
 import sys
+from typing import cast
 
 import widlparser
 
@@ -363,15 +364,15 @@ interface BigNumbers {
             print('    ' + member.idl_type + ': ' + str(member.normal_name) + ' (' + str(member.name) + ')')
 
     print("FIND:")
-    print(parser.find('round').full_name)
-    print(parser.find('Foo/method/y').full_name)
-    print(parser.find('Foo.method').full_name)
-    print(parser.find('Foo(constructor)').full_name)
-    print(parser.find('longest').full_name)
-    print(parser.find('fooArg').full_name)
-    print(parser.find('Window').full_name)
-    print(parser.find('mediaText').full_name)
-    print(parser.find('Foo.method').markup(Marker()))
+    print(cast(widlparser.Construct, parser.find('round')).full_name)
+    print(cast(widlparser.Construct, parser.find('Foo/method/y')).full_name)
+    print(cast(widlparser.Construct, parser.find('Foo.method')).full_name)
+    print(cast(widlparser.Construct, parser.find('Foo(constructor)')).full_name)
+    print(cast(widlparser.Construct, parser.find('longest')).full_name)
+    print(cast(widlparser.Construct, parser.find('fooArg')).full_name)
+    print(cast(widlparser.Construct, parser.find('Window')).full_name)
+    print(cast(widlparser.Construct, parser.find('mediaText')).full_name)
+    print(cast(widlparser.Construct, parser.find('Foo.method')).markup(Marker()))
     for method in parser.find_all('Foo.method'):
         print(method.full_name)
 

--- a/test.py
+++ b/test.py
@@ -17,6 +17,7 @@ import sys
 from typing import cast
 
 import widlparser
+from widlparser import Construct
 
 
 def debug_hook(type, value, tb):
@@ -364,15 +365,15 @@ interface BigNumbers {
             print('    ' + member.idl_type + ': ' + str(member.normal_name) + ' (' + str(member.name) + ')')
 
     print("FIND:")
-    print(cast(widlparser.Construct, parser.find('round')).full_name)
-    print(cast(widlparser.Construct, parser.find('Foo/method/y')).full_name)
-    print(cast(widlparser.Construct, parser.find('Foo.method')).full_name)
-    print(cast(widlparser.Construct, parser.find('Foo(constructor)')).full_name)
-    print(cast(widlparser.Construct, parser.find('longest')).full_name)
-    print(cast(widlparser.Construct, parser.find('fooArg')).full_name)
-    print(cast(widlparser.Construct, parser.find('Window')).full_name)
-    print(cast(widlparser.Construct, parser.find('mediaText')).full_name)
-    print(cast(widlparser.Construct, parser.find('Foo.method')).markup(Marker()))
+    print(cast(Construct, parser.find('round')).full_name)
+    print(cast(Construct, parser.find('Foo/method/y')).full_name)
+    print(cast(Construct, parser.find('Foo.method')).full_name)
+    print(cast(Construct, parser.find('Foo(constructor)')).full_name)
+    print(cast(Construct, parser.find('longest')).full_name)
+    print(cast(Construct, parser.find('fooArg')).full_name)
+    print(cast(Construct, parser.find('Window')).full_name)
+    print(cast(Construct, parser.find('mediaText')).full_name)
+    print(cast(Construct, parser.find('Foo.method')).markup(Marker()))
     for method in parser.find_all('Foo.method'):
         print(method.full_name)
 

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -11,6 +11,8 @@
 #
 """High-level WebIDL constructs."""
 
+from __future__ import annotations
+
 from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
 
 from . import markup
@@ -47,7 +49,7 @@ class Construct(ChildProduction):
 		self._symbol_table = symbol_table
 		self._extended_attributes = self._parse_extended_attributes(tokens, self) if (parse_extended_attributes) else None
 
-	def _parse_extended_attributes(self, tokens: Tokenizer, parent: "Construct") -> Optional[ExtendedAttributeList]:
+	def _parse_extended_attributes(self, tokens: Tokenizer, parent: Construct) -> Optional[ExtendedAttributeList]:
 		return ExtendedAttributeList(tokens, parent) if (ExtendedAttributeList.peek(tokens)) else None
 
 	@property
@@ -60,7 +62,7 @@ class Construct(ChildProduction):
 		return None
 
 	@property
-	def constructors(self) -> List["Construct"]:
+	def constructors(self) -> List[Construct]:
 		"""Get constructors."""
 		return [attribute for attribute in self._extended_attributes if ('constructor' == attribute.idl_type)] if (self._extended_attributes) else []
 
@@ -72,7 +74,7 @@ class Construct(ChildProduction):
 		return self.parent.symbol_table if (self.parent) else None
 
 	@property
-	def extended_attributes(self) -> Optional['ExtendedAttributeList']:
+	def extended_attributes(self) -> Optional[ExtendedAttributeList]:
 		"""Get extended attributes."""
 		return self._extended_attributes
 
@@ -84,7 +86,7 @@ class Construct(ChildProduction):
 		"""Number of children."""
 		return 0
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		"""Access child by index."""
 		raise IndexError
 
@@ -92,11 +94,11 @@ class Construct(ChildProduction):
 		"""Test if child is present."""
 		return False
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		"""Iterate over children."""
 		return iter(())
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		"""Iterate over children backwards."""
 		return iter(())
 
@@ -104,36 +106,36 @@ class Construct(ChildProduction):
 		"""Names of children."""
 		return []
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return []
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return []
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		"""Search for child member of a given name."""
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		"""Search for all child members of a given name."""
 		return []
 
-	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional["Construct"]:
+	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional[Construct]:
 		"""Search for a method of a given name."""
 		return None
 
-	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List["Construct"]:
+	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List[Construct]:
 		"""Search for all methods of a given name."""
 		return []
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		"""Search for an argument of a given name."""
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		"""Search for all arguments of a given name."""
 		return []
 
@@ -154,7 +156,7 @@ class Construct(ChildProduction):
 		"""Debug info."""
 		return repr(self._extended_attributes) if (self._extended_attributes) else ''
 
-	def define_markup(self, generator: "MarkupGenerator") -> None:
+	def define_markup(self, generator: MarkupGenerator) -> None:
 		"""Define marked up version of self."""
 		generator.add_text(self.leading_space)
 
@@ -209,7 +211,7 @@ class Const(Construct):
 						return tokens.pop_position(ConstValue.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, False, symbol_table=symbol_table)
 		self._const = Symbol(tokens, 'const')
 		self.type = ConstType(tokens)
@@ -248,7 +250,7 @@ class Const(Construct):
 		"""Convert to string."""
 		return str(self._const) + str(self.type) + str(self._name) + str(self._equals) + str(self.value)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._const.define_markup(generator)
 		generator.add_type(self.type)
 		self._name.define_markup(generator)
@@ -290,7 +292,7 @@ class Enum(Construct):
 						return tokens.pop_position((token is not None) and token.is_symbol('}'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self._enum = Symbol(tokens, 'enum')
 		self._name = Identifier(tokens)
@@ -317,7 +319,7 @@ class Enum(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self._enum) + str(self._name) + str(self._open_brace) + str(self._enum_values) + str(self._close_brace)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._enum.define_markup(generator)
 		self._name.define_markup(generator)
 		generator.add_text(self._open_brace)
@@ -351,7 +353,7 @@ class Typedef(Construct):
 				return tokens.pop_position(Identifier.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self._typedef = Symbol(tokens, 'typedef')
 		self.type = TypeWithExtendedAttributes(tokens, self)
@@ -373,7 +375,7 @@ class Typedef(Construct):
 		output = Construct._str(self) + str(self._typedef)
 		return output + str(self.type) + str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._typedef.define_markup(generator)
 		generator.add_type(self.type)
 		self._name.define_markup(generator)
@@ -455,7 +457,7 @@ class Argument(Construct):
 		output += str(self.variadic) if (self.variadic) else ''
 		return output + str(self._name) + (str(self.default) if (self.default) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.optional):
 			self.optional.define_markup(generator)
 		if (self._ignore):
@@ -498,7 +500,7 @@ class InterfaceMember(Construct):
 		                           or Attribute.peek(tokens)
 		                           or SpecialOperation.peek(tokens) or Operation.peek(tokens))
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct") -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct) -> None:
 		Construct.__init__(self, tokens, parent)
 		if (Constructor.peek(tokens)):
 			self.member = Constructor(tokens, parent)
@@ -545,17 +547,17 @@ class InterfaceMember(Construct):
 		return self.method_name if (self.method_name) else self.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.member.arguments
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			for argument in self.member.arguments:
 				if (name == argument.name):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			return [argument for argument in self.member.arguments if (name == argument.name)]
 		return []
@@ -568,7 +570,7 @@ class InterfaceMember(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self.member)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.member._define_markup(generator)
 
 	def __repr__(self) -> str:
@@ -593,7 +595,7 @@ class MixinMember(Construct):
 		return tokens.pop_position(Const.peek(tokens) or Stringifier.peek(tokens)
 		                           or MixinAttribute.peek(tokens) or Operation.peek(tokens))
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct") -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct) -> None:
 		Construct.__init__(self, tokens, parent)
 		if (Const.peek(tokens)):
 			self.member = Const(tokens, parent)
@@ -626,17 +628,17 @@ class MixinMember(Construct):
 		return self.method_name if (self.method_name) else self.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.member.arguments
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			for argument in self.member.arguments:
 				if (name == argument.name):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			return [argument for argument in self.member.arguments if (name == argument.name)]
 		return []
@@ -649,7 +651,7 @@ class MixinMember(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self.member)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.member._define_markup(generator)
 
 	def __repr__(self) -> str:
@@ -667,7 +669,7 @@ class SyntaxError(Construct):
 
 	tokens: List[Token]
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, False, symbol_table=symbol_table)
 		self.tokens = tokens.syntax_error((';', '}'), False)
 		if ((1 < len(self.tokens)) and self.tokens[-1].is_symbol('}')):
@@ -704,7 +706,7 @@ class Interface(Construct):
 	_name: Identifier
 	inheritance: Optional[Inheritance]
 	_open_brace: Symbol
-	members: List["Construct"]
+	members: List[Construct]
 	_close_brace: Optional[Symbol]
 
 	@classmethod
@@ -719,7 +721,7 @@ class Interface(Construct):
 				return tokens.pop_position(Symbol.peek(tokens, '{'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, (not parent), symbol_table=symbol_table)
 		self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
 		self._interface = Symbol(tokens, 'interface')
@@ -756,7 +758,7 @@ class Interface(Construct):
 	def __len__(self) -> int:
 		return len(self.members)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for member in self.members:
 				if (key == member.name):
@@ -772,48 +774,48 @@ class Interface(Construct):
 			return False
 		return (key in self.members)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.members)
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		return reversed(self.members)
 
 	def keys(self) -> Sequence[str]:
 		return [member.name for member in self.members if (member.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [member for member in self.members if (member.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(member.name, member) for member in self.members if (member.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (name == member.name):
 				return member
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		return [member for member in self.members if (name == member.name)]
 
-	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional["Construct"]:
+	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (('method' == member.idl_type) and (name == member.name)
 			    	and ((argument_names is None) or member.matches_argument_names(argument_names))):
 				return member
 		return None
 
-	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List["Construct"]:
+	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List[Construct]:
 		return [member for member in self.members if (('method' == member.idl_type) and (name == member.name)
 		                                              and ((argument_names is None) or member.matches_argument_names(argument_names)))]
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (search_members):
 			for member in reversed(self.members):
 				argument = member.find_argument(name)
@@ -821,8 +823,8 @@ class Interface(Construct):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
-		result: List["Construct"] = []
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
+		result: List[Construct] = []
 		if (search_members):
 			for member in self.members:
 				result += member.find_arguments(name)
@@ -839,7 +841,7 @@ class Interface(Construct):
 				output += str(member)
 		return output + str(self._close_brace) if (self._close_brace) else output
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.partial):
 			self.partial.define_markup(generator)
 		self._interface.define_markup(generator)
@@ -878,7 +880,7 @@ class Mixin(Construct):
 	_name: Identifier
 	inheritance: Optional[Inheritance]
 	_open_brace: Symbol
-	members: List["Construct"]
+	members: List[Construct]
 	_close_brace: Optional[Symbol]
 
 	@classmethod
@@ -893,7 +895,7 @@ class Mixin(Construct):
 				return tokens.pop_position(Symbol.peek(tokens, '{'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, (not parent), symbol_table=symbol_table)
 		self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
 		self._interface = Symbol(tokens, 'interface')
@@ -931,7 +933,7 @@ class Mixin(Construct):
 	def __len__(self) -> int:
 		return len(self.members)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for member in self.members:
 				if (key == member.name):
@@ -947,48 +949,48 @@ class Mixin(Construct):
 			return False
 		return (key in self.members)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.members)
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		return reversed(self.members)
 
 	def keys(self) -> Sequence[str]:
 		return [member.name for member in self.members if (member.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [member for member in self.members if (member.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(member.name, member) for member in self.members if (member.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (name == member.name):
 				return member
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		return [member for member in self.members if (name == member.name)]
 
-	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional["Construct"]:
+	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (('method' == member.idl_type) and (name == member.name)
 			    	and ((argument_names is None) or member.matches_argument_names(argument_names))):
 				return member
 		return None
 
-	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List["Construct"]:
+	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List[Construct]:
 		return [member for member in self.members if (('method' == member.idl_type) and (name == member.name)
 		                                              and ((argument_names is None) or member.matches_argument_names(argument_names)))]
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (search_members):
 			for member in reversed(self.members):
 				argument = member.find_argument(name)
@@ -996,8 +998,8 @@ class Mixin(Construct):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
-		result: List["Construct"] = []
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
+		result: List[Construct] = []
 		if (search_members):
 			for member in self.members:
 				result += member.find_arguments(name)
@@ -1014,7 +1016,7 @@ class Mixin(Construct):
 				output += str(member)
 		return output + str(self._close_brace) if (self._close_brace) else output
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.partial):
 			self.partial.define_markup(generator)
 		self._interface.define_markup(generator)
@@ -1059,7 +1061,7 @@ class NamespaceMember(Construct):
 			return tokens.pop_position(Attribute.peek(tokens))
 		return tokens.pop_position(Operation.peek(tokens) or Const.peek(tokens))
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct") -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct) -> None:
 		Construct.__init__(self, tokens, parent)
 		token = cast(Token, tokens.sneak_peek())
 		if (token.is_symbol('readonly')):
@@ -1091,17 +1093,17 @@ class NamespaceMember(Construct):
 		return self.method_name if (self.method_name) else self.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.member.arguments
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			for argument in self.member.arguments:
 				if (name == argument.name):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		if (hasattr(self.member, 'arguments') and self.member.arguments):
 			return [argument for argument in self.member.arguments if (name == argument.name)]
 		return []
@@ -1114,7 +1116,7 @@ class NamespaceMember(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self.member)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.member._define_markup(generator)
 
 	def __repr__(self) -> str:
@@ -1148,7 +1150,7 @@ class Namespace(Construct):
 				return tokens.pop_position(Symbol.peek(tokens, '{'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, (not parent), symbol_table=symbol_table)
 		self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
 		self._namespace = Symbol(tokens, 'namespace')
@@ -1184,7 +1186,7 @@ class Namespace(Construct):
 	def __len__(self) -> int:
 		return len(self.members)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for member in self.members:
 				if (key == member.name):
@@ -1200,48 +1202,48 @@ class Namespace(Construct):
 			return False
 		return (key in self.members)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.members)
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		return reversed(self.members)
 
 	def keys(self) -> Sequence[str]:
 		return [member.name for member in self.members if (member.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [member for member in self.members if (member.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(member.name, member) for member in self.members if (member.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (name == member.name):
 				return member
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		return [member for member in self.members if (name == member.name)]
 
-	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional["Construct"]:
+	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (('method' == member.idl_type) and (name == member.name)
 			    	and ((argument_names is None) or member.matches_argument_names(argument_names))):
 				return member
 		return None
 
-	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List["Construct"]:
+	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List[Construct]:
 		return [member for member in self.members if (('method' == member.idl_type) and (name == member.name)
 		                                              and ((argument_names is None) or member.matches_argument_names(argument_names)))]
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (search_members):
 			for member in reversed(self.members):
 				argument = member.find_argument(name)
@@ -1249,8 +1251,8 @@ class Namespace(Construct):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
-		result: List["Construct"] = []
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
+		result: List[Construct] = []
 		if (search_members):
 			for member in self.members:
 				result += member.find_arguments(name)
@@ -1265,7 +1267,7 @@ class Namespace(Construct):
 			output += str(member)
 		return output + str(self._close_brace) if (self._close_brace) else output
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.partial):
 			self.partial.define_markup(generator)
 		self._namespace.define_markup(generator)
@@ -1310,7 +1312,7 @@ class DictionaryMember(Construct):
 				return tokens.pop_position(True)
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None) -> None:
 		Construct.__init__(self, tokens, parent)
 		self.required = Symbol(tokens, 'required') if (Symbol.peek(tokens, 'required')) else None
 		self.type = TypeWithExtendedAttributes(tokens, self)
@@ -1333,7 +1335,7 @@ class DictionaryMember(Construct):
 		output += str(self.type) + str(self._name)
 		return output + (str(self.default) if (self.default) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.required):
 			self.required.define_markup(generator)
 		generator.add_type(self.type)
@@ -1380,7 +1382,7 @@ class Dictionary(Construct):
 				return tokens.pop_position(Symbol.peek(tokens, '{'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self.partial = Symbol(tokens, 'partial') if (Symbol.peek(tokens, 'partial')) else None
 		self._dictionary = Symbol(tokens, 'dictionary')
@@ -1424,7 +1426,7 @@ class Dictionary(Construct):
 	def __len__(self) -> int:
 		return len(self.members)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for member in self.members:
 				if (key == member.name):
@@ -1440,34 +1442,34 @@ class Dictionary(Construct):
 			return False
 		return (key in self.members)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.members)
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		return reversed(self.members)
 
 	def keys(self) -> Sequence[str]:
 		return [member.name for member in self.members if (member.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [member for member in self.members if (member.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(member.name, member) for member in self.members if (member.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		for member in reversed(self.members):
 			if (name == member.name):
 				return member
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		return [member for member in self.members if (name == member.name)]
 
 	def _str(self) -> str:
@@ -1480,7 +1482,7 @@ class Dictionary(Construct):
 			output += str(member)
 		return output + str(self._close_brace) if (self._close_brace) else output
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.partial):
 			self.partial.define_markup(generator)
 		self._dictionary.define_markup(generator)
@@ -1541,7 +1543,7 @@ class Callback(Construct):
 							return tokens.pop_position((token is not None) and token.is_symbol(')'))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self._callback = Symbol(tokens, 'callback')
 		token = cast(Token, tokens.sneak_peek())
@@ -1578,7 +1580,7 @@ class Callback(Construct):
 		return self._name.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self._arguments
 
 	@property
@@ -1588,7 +1590,7 @@ class Callback(Construct):
 	def __len__(self) -> int:
 		return len(self.interface.members) if (self.interface) else 0
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (self.interface):
 			if (isinstance(key, str)):
 				for member in self.interface.members:
@@ -1608,12 +1610,12 @@ class Callback(Construct):
 			return (key in self.interface.members)
 		return False
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		if (self.interface):
 			return iter(self.interface.members)
 		return iter(())
 
-	def __reversed__(self) -> Iterator["Construct"]:
+	def __reversed__(self) -> Iterator[Construct]:
 		if (self.interface):
 			return reversed(self.interface.members)
 		return iter(())
@@ -1621,32 +1623,32 @@ class Callback(Construct):
 	def keys(self) -> Sequence[str]:
 		return [member.name for member in self.interface.members if (member.name)] if (self.interface) else []
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [member for member in self.interface.members if (member.name)] if (self.interface) else []
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(member.name, member) for member in self.interface.members if (member.name)] if (self.interface) else []
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def find_member(self, name: str) -> Optional["Construct"]:
+	def find_member(self, name: str) -> Optional[Construct]:
 		if (self.interface):
 			for member in reversed(self.interface.members):
 				if (name == member.name):
 					return member
 		return None
 
-	def find_members(self, name: str) -> List["Construct"]:
+	def find_members(self, name: str) -> List[Construct]:
 		if (self.interface):
 			return [member for member in self.interface.members if (name == member.name)]
 		return []
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
-		argument: Optional["Construct"]
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
+		argument: Optional[Construct]
 		if (self._arguments):
 			for argument in self._arguments:
 				if (name == argument.name):
@@ -1658,7 +1660,7 @@ class Callback(Construct):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		result = []
 		if (self._arguments):
 			result = [argument for argument in self._arguments if (name == argument.name)]
@@ -1674,7 +1676,7 @@ class Callback(Construct):
 		output += str(self._name) + str(self._equals) + str(self.return_type)
 		return output + str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._callback.define_markup(generator)
 		if (self.interface):
 			return self.interface._define_markup(generator)
@@ -1716,7 +1718,7 @@ class ImplementsStatement(Construct):
 				return tokens.pop_position(TypeIdentifier.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self._name = TypeIdentifier(tokens)
 		self._implements_symbol = Symbol(tokens, 'implements')
@@ -1739,7 +1741,7 @@ class ImplementsStatement(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self._name) + str(self._implements_symbol) + str(self._implements)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._name.define_markup(generator)
 		self._implements_symbol.define_markup(generator)
 		self._implements.define_markup(generator)
@@ -1769,7 +1771,7 @@ class IncludesStatement(Construct):
 				return tokens.pop_position(TypeIdentifier.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: "Construct" = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, symbol_table=symbol_table)
 		self._name = TypeIdentifier(tokens)
 		self._includes_symbol = Symbol(tokens, 'includes')
@@ -1792,7 +1794,7 @@ class IncludesStatement(Construct):
 	def _str(self) -> str:
 		return Construct._str(self) + str(self._name) + str(self._includes_symbol) + str(self._includes)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._name.define_markup(generator)
 		self._includes_symbol.define_markup(generator)
 		self._includes.define_markup(generator)
@@ -1876,7 +1878,7 @@ class ExtendedAttributeNoArgs(Construct):
 	def _str(self) -> str:
 		return str(self._attribute)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		return self
 
@@ -1938,7 +1940,7 @@ class ExtendedAttributeArgList(Construct):
 	def _str(self) -> str:
 		return str(self._attribute) + str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		generator.add_text(self._open_paren)
 		if (self._arguments):
@@ -2003,7 +2005,7 @@ class ExtendedAttributeIdent(Construct):
 	def _str(self) -> str:
 		return str(self._attribute) + str(self._equals) + str(self._value)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		generator.add_text(self._equals)
 		self._value.define_markup(generator)
@@ -2075,7 +2077,7 @@ class ExtendedAttributeIdentList(Construct):
 		return (str(self._attribute) + str(self._equals) + str(self._open_paren) + str(self._value)
 		        + (str(self.next) if (self.next) else '') + str(self._close_paren))
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		generator.add_text(self._equals)
 		generator.add_text(self._open_paren)
@@ -2154,14 +2156,14 @@ class ExtendedAttributeNamedArgList(Construct):
 		return self.attribute
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self._arguments
 
 	def _str(self) -> str:
 		output = str(self._attribute) + str(self._equals) + str(self._value)
 		return output + str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		generator.add_text(self._equals)
 		self._value.define_markup(generator)
@@ -2230,7 +2232,7 @@ class ExtendedAttributeTypePair(Construct):
 		output = str(self._attribute) + str(self._open_paren) + str(self.key_type) + str(self._comma)
 		return output + str(self.value_type) + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._attribute.define_markup(generator)
 		generator.add_text(self._open_paren)
 		self.key_type.define_markup(generator)
@@ -2254,7 +2256,7 @@ class ExtendedAttribute(Construct):
 	| ExtendedAttributeIdentList | ExtendedAttributeTypePair
 	"""
 
-	attribute: "Construct"
+	attribute: Construct
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -2296,19 +2298,19 @@ class ExtendedAttribute(Construct):
 		return self.attribute.normal_name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		if (hasattr(self.attribute, 'arguments')):
 			return self.attribute.arguments
 		return None
 
-	def find_argument(self, name: str, search_members: bool = True) -> Optional["Construct"]:
+	def find_argument(self, name: str, search_members: bool = True) -> Optional[Construct]:
 		if (hasattr(self.attribute, 'arguments') and self.attribute.arguments):
 			for argument in self.attribute.arguments:
 				if (name == argument.name):
 					return argument
 		return None
 
-	def find_arguments(self, name: str, search_members: bool = True) -> List["Construct"]:
+	def find_arguments(self, name: str, search_members: bool = True) -> List[Construct]:
 		if (hasattr(self.attribute, 'arguments') and self.attribute.arguments):
 			return [argument for argument in self.attribute.arguments if (name == argument.name)]
 		return []
@@ -2321,7 +2323,7 @@ class ExtendedAttribute(Construct):
 	def _str(self) -> str:
 		return str(self.attribute)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.attribute._define_markup(generator)
 
 	def __repr__(self) -> str:

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -13,7 +13,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
+from typing import Any, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from . import markup
 from . import protocols
@@ -25,7 +25,7 @@ from .tokenizer import Token, Tokenizer
 
 if (TYPE_CHECKING):
 	from .markup import MarkupGenerator
-	from .productions import Production, ArgumentList
+	from .productions import Production
 
 
 def _name(thing: Any) -> str:

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -23,7 +23,7 @@ from .productions import (ArgumentList, ArgumentName, AsyncIterable, Attribute, 
                           Type, TypeIdentifier, TypeIdentifiers, TypeWithExtendedAttributes)
 from .tokenizer import Token, Tokenizer
 
-if TYPE_CHECKING:
+if (TYPE_CHECKING):
 	from .markup import MarkupGenerator
 	from .productions import Production, ArgumentList
 

--- a/widlparser/markup.py
+++ b/widlparser/markup.py
@@ -11,6 +11,8 @@
 #
 """Process markup output."""
 
+from __future__ import annotations
+
 import sys
 from typing import List, Optional, Tuple, Union, cast, TYPE_CHECKING
 
@@ -29,18 +31,18 @@ def warning(method_name: str) -> None:
 class MarkupGenerator(object):
 	"""MarkupGenerator controls the markup process for a construct."""
 
-	construct: Optional["Construct"]
-	children: List["MarkupGenerator"]
+	construct: Optional[Construct]
+	children: List[MarkupGenerator]
 
-	def __init__(self, construct: "Construct" = None) -> None:
+	def __init__(self, construct: Construct = None) -> None:
 		self.construct = construct
 		self.children = []
 
-	def add_generator(self, generator: "MarkupGenerator") -> None:
+	def add_generator(self, generator: MarkupGenerator) -> None:
 		"""Add a generator for child constructs."""
 		self.children.append(generator)
 
-	def add_type(self, type: Optional["Production"]) -> None:
+	def add_type(self, type: Optional[Production]) -> None:
 		"""Add a type."""
 		if (type):
 			self.add_text(type.leading_space)
@@ -48,51 +50,51 @@ class MarkupGenerator(object):
 			self.add_text(type.semicolon)
 			self.add_text(type.trailing_space)
 
-	def add_primitive_type(self, type: Optional["Production"]) -> None:
+	def add_primitive_type(self, type: Optional[Production]) -> None:
 		"""Add a primitive type."""
 		if (type):
 			self.children.append(MarkupPrimitiveType(self.construct, type))
 
-	def add_string_type(self, type: Optional["Production"]) -> None:
+	def add_string_type(self, type: Optional[Production]) -> None:
 		"""Add a string type."""
 		if (type):
 			self.children.append(MarkupStringType(self.construct, type))
 
-	def add_buffer_type(self, type: Optional["Production"]) -> None:
+	def add_buffer_type(self, type: Optional[Production]) -> None:
 		"""Add a buffer type."""
 		if (type):
 			self.children.append(MarkupBufferType(self.construct, type))
 
-	def add_object_type(self, type: Optional["Production"]) -> None:
+	def add_object_type(self, type: Optional[Production]) -> None:
 		"""Add an object type."""
 		if (type):
 			self.children.append(MarkupObjectType(self.construct, type))
 
-	def add_type_name(self, type_name: Optional[Union[str, "Production"]]) -> None:
+	def add_type_name(self, type_name: Optional[Union[str, Production]]) -> None:
 		"""Add a type name."""
 		if (type_name):
 			self.children.append(MarkupTypeName(self.construct, str(type_name)))
 
-	def add_name(self, name: Optional[Union[str, "Production"]]) -> None:
+	def add_name(self, name: Optional[Union[str, Production]]) -> None:
 		"""Add a name."""
 		if (name):
 			self.children.append(MarkupName(self.construct, str(name)))
 
-	def add_keyword(self, keyword: Optional[Union[str, "Production"]]) -> None:
+	def add_keyword(self, keyword: Optional[Union[str, Production]]) -> None:
 		"""Add a keyword."""
 		if (keyword):
 			self.children.append(MarkupKeyword(self.construct, str(keyword)))
 
-	def add_enum_value(self, enum_value: Optional[Union[str, "Production"]]) -> None:
+	def add_enum_value(self, enum_value: Optional[Union[str, Production]]) -> None:
 		"""Add an enum value."""
 		if (enum_value):
 			self.children.append(MarkupEnumValue(self.construct, str(enum_value)))
 
-	def add_text(self, text: Optional[Union[str, "Production"]]) -> None:
+	def add_text(self, text: Optional[Union[str, Production]]) -> None:
 		"""Add plain text."""
 		if (text):
 			if ((0 < len(self.children)) and (type(self.children[-1]) is MarkupText)):
-				cast(MarkupText, self.children[-1])._append_text(str(text))
+				cast("MarkupText", self.children[-1])._append_text(str(text))
 			else:
 				self.children.append(MarkupText(self.construct, str(text)))
 
@@ -109,10 +111,10 @@ class MarkupGenerator(object):
 			return marker.markup_construct(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupConstruct')):
 			warning('markupConstruct')
-			return cast(protocols.LegacyMarker, marker).markupConstruct(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupConstruct(self.text, self.construct)
 		return (None, None)
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate markup, calling marker."""
 		head, tail = self._markup(marker)
 		output = str(head) if (head) else ''
@@ -123,7 +125,7 @@ class MarkupGenerator(object):
 class MarkupType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup types."""
 
-	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
+	def __init__(self, construct: Optional[Construct], type: Production) -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -132,14 +134,14 @@ class MarkupType(MarkupGenerator):
 			return marker.markup_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupType')):
 			warning('markupType')
-			return cast(protocols.LegacyMarker, marker).markupType(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupType(self.text, self.construct)
 		return (None, None)
 
 
 class MarkupPrimitiveType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup primitive types."""
 
-	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
+	def __init__(self, construct: Optional[Construct], type: Production) -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -148,14 +150,14 @@ class MarkupPrimitiveType(MarkupGenerator):
 			return marker.markup_primitive_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupPrimitiveType')):
 			warning('markupPrimitiveType')
-			return cast(protocols.LegacyMarker, marker).markupPrimitiveType(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupPrimitiveType(self.text, self.construct)
 		return (None, None)
 
 
 class MarkupBufferType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup buffer types."""
 
-	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
+	def __init__(self, construct: Optional[Construct], type: Production) -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -164,14 +166,14 @@ class MarkupBufferType(MarkupGenerator):
 			return marker.markup_buffer_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupBufferType')):
 			warning('markupBufferType')
-			return cast(protocols.LegacyMarker, marker).markupBufferType(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupBufferType(self.text, self.construct)
 		return (None, None)
 
 
 class MarkupStringType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup string types."""
 
-	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
+	def __init__(self, construct: Optional[Construct], type: Production) -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -180,14 +182,14 @@ class MarkupStringType(MarkupGenerator):
 			return marker.markup_string_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupStringType')):
 			warning('markupStringType')
-			return cast(protocols.LegacyMarker, marker).markupStringType(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupStringType(self.text, self.construct)
 		return (None, None)
 
 
 class MarkupObjectType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup object types."""
 
-	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
+	def __init__(self, construct: Optional[Construct], type: Production) -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -196,7 +198,7 @@ class MarkupObjectType(MarkupGenerator):
 			return marker.markup_object_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupObjectType')):
 			warning('markupObjectType')
-			return cast(protocols.LegacyMarker, marker).markupObjectType(self.text, self.construct)
+			return cast("protocols.LegacyMarker", marker).markupObjectType(self.text, self.construct)
 		return (None, None)
 
 
@@ -205,7 +207,7 @@ class MarkupText(MarkupGenerator):
 
 	_text: str
 
-	def __init__(self, construct: Optional["Construct"], text: str) -> None:
+	def __init__(self, construct: Optional[Construct], text: str) -> None:
 		MarkupGenerator.__init__(self, construct)
 		self._text = text
 
@@ -216,7 +218,7 @@ class MarkupText(MarkupGenerator):
 	def _append_text(self, text: str) -> None:
 		self._text += text
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Use marker to encode text."""
 		return str(marker.encode(self.text)) if (hasattr(marker, 'encode')) else self.text
 
@@ -224,16 +226,16 @@ class MarkupText(MarkupGenerator):
 class MarkupTypeName(MarkupText):
 	"""MarkupGenerator subclass to markup type names."""
 
-	def __init__(self, construct: Optional["Construct"], type: str) -> None:
+	def __init__(self, construct: Optional[Construct], type: str) -> None:
 		MarkupText.__init__(self, construct, type)
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up type name."""
 		if (hasattr(marker, 'markup_type_name')):
 			head, tail = marker.markup_type_name(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupTypeName')):
 			warning('markupTypeName')
-			head, tail = cast(protocols.LegacyMarker, marker).markupTypeName(self.text, cast("Construct", construct))
+			head, tail = cast("protocols.LegacyMarker", marker).markupTypeName(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -244,16 +246,16 @@ class MarkupTypeName(MarkupText):
 class MarkupName(MarkupText):
 	"""MarkupGenerator subclass to markup names."""
 
-	def __init__(self, construct: Optional["Construct"], name: str) -> None:
+	def __init__(self, construct: Optional[Construct], name: str) -> None:
 		MarkupText.__init__(self, construct, name)
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up name."""
 		if (hasattr(marker, 'markup_name')):
 			head, tail = marker.markup_name(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupName')):
 			warning('markupName')
-			head, tail = cast(protocols.LegacyMarker, marker).markupName(self.text, cast("Construct", construct))
+			head, tail = cast("protocols.LegacyMarker", marker).markupName(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -264,16 +266,16 @@ class MarkupName(MarkupText):
 class MarkupKeyword(MarkupText):
 	"""MarkupGenerator subclass to markup keywords."""
 
-	def __init__(self, construct: Optional["Construct"], keyword: str) -> None:
+	def __init__(self, construct: Optional[Construct], keyword: str) -> None:
 		MarkupText.__init__(self, construct, keyword)
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up keyword."""
 		if (hasattr(marker, 'markup_keyword')):
 			head, tail = marker.markup_keyword(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupKeyword')):
 			warning('markupKeyword')
-			head, tail = cast(protocols.LegacyMarker, marker).markupKeyword(self.text, cast("Construct", construct))
+			head, tail = cast("protocols.LegacyMarker", marker).markupKeyword(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -284,16 +286,16 @@ class MarkupKeyword(MarkupText):
 class MarkupEnumValue(MarkupText):
 	"""MarkupGenerator subclass to markup enum values."""
 
-	def __init__(self, construct: Optional["Construct"], keyword: str) -> None:
+	def __init__(self, construct: Optional[Construct], keyword: str) -> None:
 		MarkupText.__init__(self, construct, str(keyword))
 
-	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up enum value."""
 		if (hasattr(marker, 'markup_enum_value')):
 			head, tail = marker.markup_enum_value(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupEnumValue')):
 			warning('markupEnumValue')
-			head, tail = cast(protocols.LegacyMarker, marker).markupEnumValue(self.text, cast("Construct", construct))
+			head, tail = cast("protocols.LegacyMarker", marker).markupEnumValue(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''

--- a/widlparser/markup.py
+++ b/widlparser/markup.py
@@ -12,9 +12,13 @@
 """Process markup output."""
 
 import sys
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast, TYPE_CHECKING
 
 from . import protocols
+
+if TYPE_CHECKING:
+	from .productions import Production
+	from .constructs import Construct
 
 
 def warning(method_name: str) -> None:
@@ -25,18 +29,18 @@ def warning(method_name: str) -> None:
 class MarkupGenerator(object):
 	"""MarkupGenerator controls the markup process for a construct."""
 
-	construct: Optional[protocols.Construct]
-	children: List[protocols.MarkupGenerator]
+	construct: Optional["Construct"]
+	children: List["MarkupGenerator"]
 
-	def __init__(self, construct: protocols.Construct = None) -> None:
+	def __init__(self, construct: "Construct" = None) -> None:
 		self.construct = construct
 		self.children = []
 
-	def add_generator(self, generator: protocols.MarkupGenerator) -> None:
+	def add_generator(self, generator: "MarkupGenerator") -> None:
 		"""Add a generator for child constructs."""
 		self.children.append(generator)
 
-	def add_type(self, type: Optional[protocols.Production]) -> None:
+	def add_type(self, type: Optional["Production"]) -> None:
 		"""Add a type."""
 		if (type):
 			self.add_text(type.leading_space)
@@ -44,47 +48,47 @@ class MarkupGenerator(object):
 			self.add_text(type.semicolon)
 			self.add_text(type.trailing_space)
 
-	def add_primitive_type(self, type: Optional[protocols.Production]) -> None:
+	def add_primitive_type(self, type: Optional["Production"]) -> None:
 		"""Add a primitive type."""
 		if (type):
 			self.children.append(MarkupPrimitiveType(self.construct, type))
 
-	def add_string_type(self, type: Optional[protocols.Production]) -> None:
+	def add_string_type(self, type: Optional["Production"]) -> None:
 		"""Add a string type."""
 		if (type):
 			self.children.append(MarkupStringType(self.construct, type))
 
-	def add_buffer_type(self, type: Optional[protocols.Production]) -> None:
+	def add_buffer_type(self, type: Optional["Production"]) -> None:
 		"""Add a buffer type."""
 		if (type):
 			self.children.append(MarkupBufferType(self.construct, type))
 
-	def add_object_type(self, type: Optional[protocols.Production]) -> None:
+	def add_object_type(self, type: Optional["Production"]) -> None:
 		"""Add an object type."""
 		if (type):
 			self.children.append(MarkupObjectType(self.construct, type))
 
-	def add_type_name(self, type_name: Optional[Union[str, protocols.Production]]) -> None:
+	def add_type_name(self, type_name: Optional[Union[str, "Production"]]) -> None:
 		"""Add a type name."""
 		if (type_name):
 			self.children.append(MarkupTypeName(self.construct, str(type_name)))
 
-	def add_name(self, name: Optional[Union[str, protocols.Production]]) -> None:
+	def add_name(self, name: Optional[Union[str, "Production"]]) -> None:
 		"""Add a name."""
 		if (name):
 			self.children.append(MarkupName(self.construct, str(name)))
 
-	def add_keyword(self, keyword: Optional[Union[str, protocols.Production]]) -> None:
+	def add_keyword(self, keyword: Optional[Union[str, "Production"]]) -> None:
 		"""Add a keyword."""
 		if (keyword):
 			self.children.append(MarkupKeyword(self.construct, str(keyword)))
 
-	def add_enum_value(self, enum_value: Optional[Union[str, protocols.Production]]) -> None:
+	def add_enum_value(self, enum_value: Optional[Union[str, "Production"]]) -> None:
 		"""Add an enum value."""
 		if (enum_value):
 			self.children.append(MarkupEnumValue(self.construct, str(enum_value)))
 
-	def add_text(self, text: Optional[Union[str, protocols.Production]]) -> None:
+	def add_text(self, text: Optional[Union[str, "Production"]]) -> None:
 		"""Add plain text."""
 		if (text):
 			if ((0 < len(self.children)) and (type(self.children[-1]) is MarkupText)):
@@ -108,7 +112,7 @@ class MarkupGenerator(object):
 			return cast(protocols.LegacyMarker, marker).markupConstruct(self.text, self.construct)
 		return (None, None)
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Generate markup, calling marker."""
 		head, tail = self._markup(marker)
 		output = str(head) if (head) else ''
@@ -119,7 +123,7 @@ class MarkupGenerator(object):
 class MarkupType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup types."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: protocols.Production) -> None:
+	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -135,7 +139,7 @@ class MarkupType(MarkupGenerator):
 class MarkupPrimitiveType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup primitive types."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: protocols.Production) -> None:
+	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -151,7 +155,7 @@ class MarkupPrimitiveType(MarkupGenerator):
 class MarkupBufferType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup buffer types."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: protocols.Production) -> None:
+	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -167,7 +171,7 @@ class MarkupBufferType(MarkupGenerator):
 class MarkupStringType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup string types."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: protocols.Production) -> None:
+	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -183,7 +187,7 @@ class MarkupStringType(MarkupGenerator):
 class MarkupObjectType(MarkupGenerator):
 	"""MarkupGenerator subclass to markup object types."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: protocols.Production) -> None:
+	def __init__(self, construct: Optional["Construct"], type: "Production") -> None:
 		MarkupGenerator.__init__(self, construct)
 		type._define_markup(self)
 
@@ -201,7 +205,7 @@ class MarkupText(MarkupGenerator):
 
 	_text: str
 
-	def __init__(self, construct: Optional[protocols.Construct], text: str) -> None:
+	def __init__(self, construct: Optional["Construct"], text: str) -> None:
 		MarkupGenerator.__init__(self, construct)
 		self._text = text
 
@@ -212,7 +216,7 @@ class MarkupText(MarkupGenerator):
 	def _append_text(self, text: str) -> None:
 		self._text += text
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Use marker to encode text."""
 		return str(marker.encode(self.text)) if (hasattr(marker, 'encode')) else self.text
 
@@ -220,16 +224,16 @@ class MarkupText(MarkupGenerator):
 class MarkupTypeName(MarkupText):
 	"""MarkupGenerator subclass to markup type names."""
 
-	def __init__(self, construct: Optional[protocols.Construct], type: str) -> None:
+	def __init__(self, construct: Optional["Construct"], type: str) -> None:
 		MarkupText.__init__(self, construct, type)
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Generate marked up type name."""
 		if (hasattr(marker, 'markup_type_name')):
-			head, tail = marker.markup_type_name(self.text, cast(protocols.Construct, construct))
+			head, tail = marker.markup_type_name(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupTypeName')):
 			warning('markupTypeName')
-			head, tail = cast(protocols.LegacyMarker, marker).markupTypeName(self.text, cast(protocols.Construct, construct))
+			head, tail = cast(protocols.LegacyMarker, marker).markupTypeName(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -240,16 +244,16 @@ class MarkupTypeName(MarkupText):
 class MarkupName(MarkupText):
 	"""MarkupGenerator subclass to markup names."""
 
-	def __init__(self, construct: Optional[protocols.Construct], name: str) -> None:
+	def __init__(self, construct: Optional["Construct"], name: str) -> None:
 		MarkupText.__init__(self, construct, name)
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Generate marked up name."""
 		if (hasattr(marker, 'markup_name')):
-			head, tail = marker.markup_name(self.text, cast(protocols.Construct, construct))
+			head, tail = marker.markup_name(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupName')):
 			warning('markupName')
-			head, tail = cast(protocols.LegacyMarker, marker).markupName(self.text, cast(protocols.Construct, construct))
+			head, tail = cast(protocols.LegacyMarker, marker).markupName(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -260,16 +264,16 @@ class MarkupName(MarkupText):
 class MarkupKeyword(MarkupText):
 	"""MarkupGenerator subclass to markup keywords."""
 
-	def __init__(self, construct: Optional[protocols.Construct], keyword: str) -> None:
+	def __init__(self, construct: Optional["Construct"], keyword: str) -> None:
 		MarkupText.__init__(self, construct, keyword)
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Generate marked up keyword."""
 		if (hasattr(marker, 'markup_keyword')):
-			head, tail = marker.markup_keyword(self.text, cast(protocols.Construct, construct))
+			head, tail = marker.markup_keyword(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupKeyword')):
 			warning('markupKeyword')
-			head, tail = cast(protocols.LegacyMarker, marker).markupKeyword(self.text, cast(protocols.Construct, construct))
+			head, tail = cast(protocols.LegacyMarker, marker).markupKeyword(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -280,16 +284,16 @@ class MarkupKeyword(MarkupText):
 class MarkupEnumValue(MarkupText):
 	"""MarkupGenerator subclass to markup enum values."""
 
-	def __init__(self, construct: Optional[protocols.Construct], keyword: str) -> None:
+	def __init__(self, construct: Optional["Construct"], keyword: str) -> None:
 		MarkupText.__init__(self, construct, str(keyword))
 
-	def markup(self, marker: protocols.Marker, construct: protocols.Construct = None) -> str:
+	def markup(self, marker: protocols.Marker, construct: "Construct" = None) -> str:
 		"""Generate marked up enum value."""
 		if (hasattr(marker, 'markup_enum_value')):
-			head, tail = marker.markup_enum_value(self.text, cast(protocols.Construct, construct))
+			head, tail = marker.markup_enum_value(self.text, cast("Construct", construct))
 		elif (hasattr(marker, 'markupEnumValue')):
 			warning('markupEnumValue')
-			head, tail = cast(protocols.LegacyMarker, marker).markupEnumValue(self.text, cast(protocols.Construct, construct))
+			head, tail = cast(protocols.LegacyMarker, marker).markupEnumValue(self.text, cast("Construct", construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''

--- a/widlparser/markup.py
+++ b/widlparser/markup.py
@@ -18,7 +18,7 @@ from typing import List, Optional, Tuple, Union, cast, TYPE_CHECKING
 
 from . import protocols
 
-if TYPE_CHECKING:
+if (TYPE_CHECKING):
 	from .productions import Production
 	from .constructs import Construct
 

--- a/widlparser/markup.py
+++ b/widlparser/markup.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import sys
-from typing import List, Optional, Tuple, Union, cast, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING, Tuple, Union, cast
 
 from . import protocols
 
@@ -94,7 +94,7 @@ class MarkupGenerator(object):
 		"""Add plain text."""
 		if (text):
 			if ((0 < len(self.children)) and (type(self.children[-1]) is MarkupText)):
-				cast("MarkupText", self.children[-1])._append_text(str(text))
+				cast('MarkupText', self.children[-1])._append_text(str(text))
 			else:
 				self.children.append(MarkupText(self.construct, str(text)))
 
@@ -111,7 +111,7 @@ class MarkupGenerator(object):
 			return marker.markup_construct(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupConstruct')):
 			warning('markupConstruct')
-			return cast("protocols.LegacyMarker", marker).markupConstruct(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupConstruct(self.text, self.construct)
 		return (None, None)
 
 	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
@@ -134,7 +134,7 @@ class MarkupType(MarkupGenerator):
 			return marker.markup_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupType')):
 			warning('markupType')
-			return cast("protocols.LegacyMarker", marker).markupType(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupType(self.text, self.construct)
 		return (None, None)
 
 
@@ -150,7 +150,7 @@ class MarkupPrimitiveType(MarkupGenerator):
 			return marker.markup_primitive_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupPrimitiveType')):
 			warning('markupPrimitiveType')
-			return cast("protocols.LegacyMarker", marker).markupPrimitiveType(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupPrimitiveType(self.text, self.construct)
 		return (None, None)
 
 
@@ -166,7 +166,7 @@ class MarkupBufferType(MarkupGenerator):
 			return marker.markup_buffer_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupBufferType')):
 			warning('markupBufferType')
-			return cast("protocols.LegacyMarker", marker).markupBufferType(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupBufferType(self.text, self.construct)
 		return (None, None)
 
 
@@ -182,7 +182,7 @@ class MarkupStringType(MarkupGenerator):
 			return marker.markup_string_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupStringType')):
 			warning('markupStringType')
-			return cast("protocols.LegacyMarker", marker).markupStringType(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupStringType(self.text, self.construct)
 		return (None, None)
 
 
@@ -198,7 +198,7 @@ class MarkupObjectType(MarkupGenerator):
 			return marker.markup_object_type(self.text, self.construct)
 		if (self.construct and hasattr(marker, 'markupObjectType')):
 			warning('markupObjectType')
-			return cast("protocols.LegacyMarker", marker).markupObjectType(self.text, self.construct)
+			return cast('protocols.LegacyMarker', marker).markupObjectType(self.text, self.construct)
 		return (None, None)
 
 
@@ -232,10 +232,10 @@ class MarkupTypeName(MarkupText):
 	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up type name."""
 		if (hasattr(marker, 'markup_type_name')):
-			head, tail = marker.markup_type_name(self.text, cast("Construct", construct))
+			head, tail = marker.markup_type_name(self.text, cast('Construct', construct))
 		elif (hasattr(marker, 'markupTypeName')):
 			warning('markupTypeName')
-			head, tail = cast("protocols.LegacyMarker", marker).markupTypeName(self.text, cast("Construct", construct))
+			head, tail = cast('protocols.LegacyMarker', marker).markupTypeName(self.text, cast('Construct', construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -252,10 +252,10 @@ class MarkupName(MarkupText):
 	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up name."""
 		if (hasattr(marker, 'markup_name')):
-			head, tail = marker.markup_name(self.text, cast("Construct", construct))
+			head, tail = marker.markup_name(self.text, cast('Construct', construct))
 		elif (hasattr(marker, 'markupName')):
 			warning('markupName')
-			head, tail = cast("protocols.LegacyMarker", marker).markupName(self.text, cast("Construct", construct))
+			head, tail = cast('protocols.LegacyMarker', marker).markupName(self.text, cast('Construct', construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -272,10 +272,10 @@ class MarkupKeyword(MarkupText):
 	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up keyword."""
 		if (hasattr(marker, 'markup_keyword')):
-			head, tail = marker.markup_keyword(self.text, cast("Construct", construct))
+			head, tail = marker.markup_keyword(self.text, cast('Construct', construct))
 		elif (hasattr(marker, 'markupKeyword')):
 			warning('markupKeyword')
-			head, tail = cast("protocols.LegacyMarker", marker).markupKeyword(self.text, cast("Construct", construct))
+			head, tail = cast('protocols.LegacyMarker', marker).markupKeyword(self.text, cast('Construct', construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''
@@ -292,10 +292,10 @@ class MarkupEnumValue(MarkupText):
 	def markup(self, marker: protocols.Marker, construct: Construct = None) -> str:
 		"""Generate marked up enum value."""
 		if (hasattr(marker, 'markup_enum_value')):
-			head, tail = marker.markup_enum_value(self.text, cast("Construct", construct))
+			head, tail = marker.markup_enum_value(self.text, cast('Construct', construct))
 		elif (hasattr(marker, 'markupEnumValue')):
 			warning('markupEnumValue')
-			head, tail = cast("protocols.LegacyMarker", marker).markupEnumValue(self.text, cast("Construct", construct))
+			head, tail = cast('protocols.LegacyMarker', marker).markupEnumValue(self.text, cast('Construct', construct))
 		else:
 			head, tail = (None, None)
 		output = str(head) if (head) else ''

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -22,7 +22,7 @@ from . import markup
 from . import protocols
 from . import tokenizer
 
-if TYPE_CHECKING:
+if (TYPE_CHECKING):
 	from .constructs import Construct
 
 

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -11,6 +11,8 @@
 #
 """Parser class to parse WebIDL."""
 
+from __future__ import annotations
+
 import itertools
 import re
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
@@ -28,8 +30,8 @@ class Parser(object):
 	"""Class to parse WebIDL."""
 
 	ui: Optional[tokenizer.UserInterface]
-	symbol_table: Dict[str, "Construct"]
-	constructs: List["Construct"]
+	symbol_table: Dict[str, Construct]
+	constructs: List[Construct]
 
 	def __init__(self, text: str = None, ui: tokenizer.UserInterface = None, symbol_table: dict = None) -> None:
 		self.ui = ui
@@ -98,7 +100,7 @@ class Parser(object):
 		"""Number of parsed constucts."""
 		return len(self.constructs)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		"""Access a construct by name or index."""
 		if (isinstance(key, str)):
 			for construct in self.constructs:
@@ -116,7 +118,7 @@ class Parser(object):
 			return False
 		return (key in self.constructs)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		"""Get an iterator for the constructs."""
 		return iter(self.constructs)
 
@@ -124,28 +126,28 @@ class Parser(object):
 		"""Names of all constructs."""
 		return [construct.name for construct in self.constructs if (construct.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [construct for construct in self.constructs if (construct.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(construct.name, construct) for construct in self.constructs if (construct.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def add_type(self, type: "Construct") -> None:
+	def add_type(self, type: Construct) -> None:
 		"""Add a type to the symbol table."""
 		if (type.name):
 			self.symbol_table[type.name] = type
 
-	def get_type(self, name: str) -> Optional["Construct"]:
+	def get_type(self, name: str) -> Optional[Construct]:
 		"""Lookup a type in the symbol table."""
 		return self.symbol_table.get(name)
 
-	def find(self, name: str) -> Optional["Construct"]:
+	def find(self, name: str) -> Optional[Construct]:
 		"""
 		Find a construct by name.
 
@@ -162,8 +164,8 @@ class Parser(object):
 		elif ('.' in name):
 			path = name.split('.')
 
-		construct: Optional["Construct"]
-		member: Optional["Construct"]
+		construct: Optional[Construct]
+		member: Optional[Construct]
 		if (path):
 			construct_name = path[0]
 			member_name = path[1]
@@ -205,7 +207,7 @@ class Parser(object):
 
 		return None
 
-	def find_all(self, name: str) -> List["Construct"]:
+	def find_all(self, name: str) -> List[Construct]:
 		"""
 		Find all constructs with a given name.
 
@@ -285,7 +287,7 @@ class Parser(object):
 					return cast(str, method.method_name)
 			return name + '(' + ', '.join(argument_names or []) + ')'
 
-		construct: Optional["Construct"]
+		construct: Optional[Construct]
 		for construct in self.constructs:
 			method = construct.find_method(name, argument_names)
 			if (method):
@@ -319,7 +321,7 @@ class Parser(object):
 					return list(itertools.chain(*[method.method_names for method in methods]))
 			return [name + '(' + ', '.join(argument_names or []) + ')']
 
-		construct: Optional["Construct"]
+		construct: Optional[Construct]
 		for construct in self.constructs:
 			methods = construct.find_methods(name, argument_names)
 			if (methods):

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -13,20 +13,23 @@
 
 import itertools
 import re
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
 
 from . import constructs
 from . import markup
 from . import protocols
 from . import tokenizer
 
+if TYPE_CHECKING:
+	from .constructs import Construct
+
 
 class Parser(object):
 	"""Class to parse WebIDL."""
 
 	ui: Optional[tokenizer.UserInterface]
-	symbol_table: Dict[str, protocols.Construct]
-	constructs: List[protocols.Construct]
+	symbol_table: Dict[str, "Construct"]
+	constructs: List["Construct"]
 
 	def __init__(self, text: str = None, ui: tokenizer.UserInterface = None, symbol_table: dict = None) -> None:
 		self.ui = ui
@@ -95,7 +98,7 @@ class Parser(object):
 		"""Number of parsed constucts."""
 		return len(self.constructs)
 
-	def __getitem__(self, key: Union[str, int]) -> protocols.Construct:
+	def __getitem__(self, key: Union[str, int]) -> "Construct":
 		"""Access a construct by name or index."""
 		if (isinstance(key, str)):
 			for construct in self.constructs:
@@ -113,7 +116,7 @@ class Parser(object):
 			return False
 		return (key in self.constructs)
 
-	def __iter__(self) -> Iterator[protocols.Construct]:
+	def __iter__(self) -> Iterator["Construct"]:
 		"""Get an iterator for the constructs."""
 		return iter(self.constructs)
 
@@ -121,28 +124,28 @@ class Parser(object):
 		"""Names of all constructs."""
 		return [construct.name for construct in self.constructs if (construct.name)]
 
-	def values(self) -> Sequence[protocols.Construct]:
+	def values(self) -> Sequence["Construct"]:
 		return [construct for construct in self.constructs if (construct.name)]
 
-	def items(self) -> Sequence[Tuple[str, protocols.Construct]]:
+	def items(self) -> Sequence[Tuple[str, "Construct"]]:
 		return [(construct.name, construct) for construct in self.constructs if (construct.name)]
 
-	def get(self, key: Union[str, int]) -> Optional[protocols.Construct]:
+	def get(self, key: Union[str, int]) -> Optional["Construct"]:
 		try:
 			return self[key]
 		except IndexError:
 			return None
 
-	def add_type(self, type: protocols.Construct) -> None:
+	def add_type(self, type: "Construct") -> None:
 		"""Add a type to the symbol table."""
 		if (type.name):
 			self.symbol_table[type.name] = type
 
-	def get_type(self, name: str) -> Optional[protocols.Construct]:
+	def get_type(self, name: str) -> Optional["Construct"]:
 		"""Lookup a type in the symbol table."""
 		return self.symbol_table.get(name)
 
-	def find(self, name: str) -> Optional[protocols.Construct]:
+	def find(self, name: str) -> Optional["Construct"]:
 		"""
 		Find a construct by name.
 
@@ -159,8 +162,8 @@ class Parser(object):
 		elif ('.' in name):
 			path = name.split('.')
 
-		construct: Optional[protocols.Construct]
-		member: Optional[protocols.Construct]
+		construct: Optional["Construct"]
+		member: Optional["Construct"]
 		if (path):
 			construct_name = path[0]
 			member_name = path[1]
@@ -202,7 +205,7 @@ class Parser(object):
 
 		return None
 
-	def find_all(self, name: str) -> List[protocols.Construct]:
+	def find_all(self, name: str) -> List["Construct"]:
 		"""
 		Find all constructs with a given name.
 
@@ -282,7 +285,7 @@ class Parser(object):
 					return cast(str, method.method_name)
 			return name + '(' + ', '.join(argument_names or []) + ')'
 
-		construct: Optional[protocols.Construct]
+		construct: Optional["Construct"]
 		for construct in self.constructs:
 			method = construct.find_method(name, argument_names)
 			if (method):
@@ -316,7 +319,7 @@ class Parser(object):
 					return list(itertools.chain(*[method.method_names for method in methods]))
 			return [name + '(' + ', '.join(argument_names or []) + ')']
 
-		construct: Optional[protocols.Construct]
+		construct: Optional["Construct"]
 		for construct in self.constructs:
 			methods = construct.find_methods(name, argument_names)
 			if (methods):

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import itertools
 import re
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
+from typing import Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from . import constructs
 from . import markup

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -21,7 +21,7 @@ from . import constructs, tokenizer
 from . import protocols
 from .tokenizer import Token, Tokenizer
 
-if TYPE_CHECKING:
+if (TYPE_CHECKING):
 	from .markup import MarkupGenerator
 	from .constructs import Construct
 

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 
 import itertools
-from typing import Any, Container, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
+from typing import Any, Container, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from . import constructs, tokenizer
 from . import protocols
@@ -106,9 +106,9 @@ class Production(object):
 class ChildProduction(Production):
 	"""Base class for productions that have parents."""
 
-	parent: Optional["ChildProduction"]
+	parent: Optional[ChildProduction]
 
-	def __init__(self, tokens: Tokenizer, parent: Optional["ChildProduction"]) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Optional[ChildProduction]) -> None:
 		Production.__init__(self, tokens)
 		self.parent = parent
 

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -11,6 +11,8 @@
 #
 """Basic language productions for WebIDL."""
 
+from __future__ import annotations
+
 
 import itertools
 from typing import Any, Container, Iterator, List, Optional, Sequence, Tuple, Union, cast, TYPE_CHECKING
@@ -38,7 +40,7 @@ class Production(object):
 
 	leading_space: str
 	_tail: Optional[List[tokenizer.Token]]
-	semicolon: Union[str, "Production"]
+	semicolon: Union[str, Production]
 	trailing_space: str
 
 	def __init__(self, tokens: Tokenizer) -> None:
@@ -72,11 +74,11 @@ class Production(object):
 	def __str__(self) -> str:
 		return self.leading_space + self._str() + self.tail + str(self.semicolon) + self.trailing_space
 
-	def _define_markup(self, generator: "MarkupGenerator") -> "Production":
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self._str())
 		return self
 
-	def define_markup(self, generator: "MarkupGenerator") -> None:
+	def define_markup(self, generator: MarkupGenerator) -> None:
 		generator.add_text(self.leading_space)
 		target = self._define_markup(generator)
 		generator.add_text(target.tail)
@@ -129,7 +131,7 @@ class ChildProduction(Production):
 		return []
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	@property
@@ -160,7 +162,7 @@ class String(Production):
 	def _str(self) -> str:
 		return self.string
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self.string)
 		return self
 
@@ -193,7 +195,7 @@ class Symbol(Production):
 	def _str(self) -> str:
 		return self.symbol
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.symbol in tokenizer.Tokenizer.SYMBOL_IDENTS):
 			generator.add_keyword(self.symbol)
 		else:
@@ -227,7 +229,7 @@ class Integer(Production):
 	def _str(self) -> str:
 		return self.integer
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self.integer)
 		return self
 
@@ -276,7 +278,7 @@ class IntegerType(Production):
 			return self._space.join(self.type.split(' '))
 		return self.type
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self._space):
 			keywords = self.type.split(' ')
 			generator.add_keyword(keywords[0])
@@ -319,7 +321,7 @@ class UnsignedIntegerType(Production):
 	def _str(self) -> str:
 		return (str(self.unsigned) + self.type._str()) if (self.unsigned) else self.type._str()
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.unsigned):
 			self.unsigned.define_markup(generator)
 		return self.type._define_markup(generator)
@@ -352,7 +354,7 @@ class FloatType(Production):
 	def _str(self) -> str:
 		return self.type
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_keyword(self.type)
 		return self
 
@@ -389,7 +391,7 @@ class UnrestrictedFloatType(Production):
 	def _str(self) -> str:
 		return (str(self.unrestricted) + str(self.type)) if (self.unrestricted) else str(self.type)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.unrestricted):
 			self.unrestricted.define_markup(generator)
 		return self.type._define_markup(generator)
@@ -429,7 +431,7 @@ class PrimitiveType(Production):
 	def _str(self) -> str:
 		return self.type._str()
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.type._define_markup(generator)
 
 	def __repr__(self) -> str:
@@ -463,7 +465,7 @@ class Identifier(Production):
 	def _str(self) -> str:
 		return str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_name(self._name)
 		return self
 
@@ -502,7 +504,7 @@ class TypeIdentifier(Production):
 	def _str(self) -> str:
 		return str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_type_name(self._name)
 		return self
 
@@ -548,7 +550,7 @@ class ConstType(Production):
 	def _str(self) -> str:
 		return str(self.type) + (str(self.null) if (self.null) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (isinstance(self.type, TypeIdentifier)):
 			self.type.define_markup(generator)
 			if (self.null):
@@ -589,7 +591,7 @@ class FloatLiteral(Production):
 	def _str(self) -> str:
 		return self.value
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.value in tokenizer.Tokenizer.SYMBOL_IDENTS):
 			generator.add_keyword(self.value)
 		else:
@@ -630,7 +632,7 @@ class ConstValue(Production):
 	def _str(self) -> str:
 		return str(self.value)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (isinstance(self.value, str)):
 			if (self.value in tokenizer.Tokenizer.SYMBOL_IDENTS):
 				generator.add_keyword(self.value)
@@ -663,7 +665,7 @@ class EnumValue(Production):
 		self.value = next(tokens).text
 		self._did_parse(tokens)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_enum_value(self.value)
 		return self
 
@@ -715,7 +717,7 @@ class EnumValueList(Production):
 			break
 		self._did_parse(tokens)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		for value, _comma in itertools.zip_longest(self.values, self._commas, fillvalue=''):
 			value.define_markup(generator)
 			if (_comma):
@@ -852,7 +854,7 @@ class AnyType(Production):
 	def _str(self) -> str:
 		return str(self.any) + (str(self.suffix) if (self.suffix) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self.any.define_markup(generator)
 		if (self.suffix):
 			self.suffix.define_markup(generator)
@@ -895,7 +897,7 @@ class SingleType(ChildProduction):
 	def _str(self) -> str:
 		return str(self.type)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self.type._define_markup(generator)
 		return self
 
@@ -1033,7 +1035,7 @@ class NonAnyType(ChildProduction):
 		output = output + (str(self.null) if (self.null) else '')
 		return output + (str(self.suffix) if (self.suffix) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.sequence):
 			self.sequence.define_markup(generator)
 			generator.add_text(self._open_type)
@@ -1097,7 +1099,7 @@ class UnionMemberType(ChildProduction):
 
 	type: Union[NonAnyType, 'UnionType', AnyType]
 	suffix: Optional[TypeSuffix]
-	_extended_attributes: Optional['ExtendedAttributeList']
+	_extended_attributes: Optional[ExtendedAttributeList]
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -1125,7 +1127,7 @@ class UnionMemberType(ChildProduction):
 		self._did_parse(tokens, False)
 
 	@property
-	def extended_attributes(self) -> Optional['ExtendedAttributeList']:
+	def extended_attributes(self) -> Optional[ExtendedAttributeList]:
 		return self._extended_attributes
 
 	@property
@@ -1141,7 +1143,7 @@ class UnionMemberType(ChildProduction):
 		output += str(self.type)
 		return output + (str(self.suffix) if (self.suffix) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self._extended_attributes):
 			self._extended_attributes.define_markup(generator)
 		self.type.define_markup(generator)
@@ -1211,7 +1213,7 @@ class UnionType(ChildProduction):
 		output += ''.join([str(type) + str(_or) for type, _or in itertools.zip_longest(self.types, self._ors, fillvalue='')])
 		return output + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self._open_paren)
 		for type, _or in itertools.zip_longest(self.types, self._ors, fillvalue=''):
 			generator.add_type(type)
@@ -1261,7 +1263,7 @@ class Type(ChildProduction):
 	def _str(self) -> str:
 		return str(self.type) + (self.suffix._str() if (self.suffix) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self.type.define_markup(generator)
 		generator.add_text(self.suffix)
 		return self
@@ -1278,7 +1280,7 @@ class TypeWithExtendedAttributes(ChildProduction):
 	[ExtendedAttributeList] SingleType | UnionType [TypeSuffix]
 	"""
 
-	_extended_attributes: Optional['ExtendedAttributeList']
+	_extended_attributes: Optional[ExtendedAttributeList]
 	type: Union[SingleType, UnionType]
 	suffix: Optional[TypeSuffix]
 
@@ -1308,13 +1310,13 @@ class TypeWithExtendedAttributes(ChildProduction):
 		return self.type.type_names
 
 	@property
-	def extended_attributes(self) -> Optional['ExtendedAttributeList']:
+	def extended_attributes(self) -> Optional[ExtendedAttributeList]:
 		return self._extended_attributes
 
 	def _str(self) -> str:
 		return (str(self._extended_attributes) if (self._extended_attributes) else '') + str(self.type) + (self.suffix._str() if (self.suffix) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self._extended_attributes):
 			self._extended_attributes.define_markup(generator)
 		self.type.define_markup(generator)
@@ -1435,7 +1437,7 @@ class IgnoreMultipleInheritance(Production):
 	def inherit(self) -> str:
 		return _name(self._inherit)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self._comma)
 		self._inherit.define_markup(generator)
 		if (self.next):
@@ -1478,7 +1480,7 @@ class Inheritance(Production):
 	def _str(self) -> str:
 		return str(self._colon) + str(self._base) + (str(self._ignore) if (self._ignore) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self._colon)
 		self._base.define_markup(generator)
 		if (self._ignore):
@@ -1542,7 +1544,7 @@ class Default(Production):
 	def _str(self) -> str:
 		return str(self._equals) + (str(self._value) if (self._value) else str(self._open) + str(self._close))
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._equals.define_markup(generator)
 		if (self._value):
 			return self._value._define_markup(generator)
@@ -1589,7 +1591,7 @@ class ArgumentName(Production):
 	def _str(self) -> str:
 		return str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._name.define_markup(generator)
 		return self
 
@@ -1681,7 +1683,7 @@ class ArgumentList(Production):
 	def __len__(self) -> int:
 		return len(self.arguments)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for argument in self.arguments:
 				if (argument.name == key):
@@ -1697,19 +1699,19 @@ class ArgumentList(Production):
 			return False
 		return (key in self.arguments)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.arguments)
 
 	def keys(self) -> Sequence[str]:
 		return [argument.name for argument in self.arguments if (argument.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [argument for argument in self.arguments if (argument.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(argument.name, argument) for argument in self.arguments if (argument.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
@@ -1718,7 +1720,7 @@ class ArgumentList(Production):
 	def _str(self) -> str:
 		return ''.join([str(argument) + str(comma) for argument, comma in itertools.zip_longest(self.arguments, self._commas, fillvalue='')])
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		for argument, comma in itertools.zip_longest(self.arguments, self._commas, fillvalue=''):
 			argument.define_markup(generator)
 			generator.add_text(comma)
@@ -1757,7 +1759,7 @@ class Special(Production):
 	def _str(self) -> str:
 		return self._name
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_keyword(self._name)
 		return self
 
@@ -1794,7 +1796,7 @@ class AttributeName(Production):
 	def _str(self) -> str:
 		return str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._name.define_markup(generator)
 		return self
 
@@ -1846,7 +1848,7 @@ class AttributeRest(ChildProduction):
 		output += str(self._name)
 		return output + (str(self._ignore) if (self._ignore) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.readonly):
 			self.readonly.define_markup(generator)
 		self._attribute.define_markup(generator)
@@ -1896,13 +1898,13 @@ class MixinAttribute(ChildProduction):
 		return self.attribute.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	def _str(self) -> str:
 		return str(self.attribute)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		return self.attribute._define_markup(generator)
 
 	def __repr__(self) -> str:
@@ -1946,14 +1948,14 @@ class Attribute(ChildProduction):
 		return self.attribute.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	def _str(self) -> str:
 		output = str(self.inherit) if (self.inherit) else ''
 		return output + str(self.attribute)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.inherit):
 			self.inherit.define_markup(generator)
 		return self.attribute._define_markup(generator)
@@ -1993,7 +1995,7 @@ class OperationName(Production):
 	def _str(self) -> str:
 		return str(self._name)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._name.define_markup(generator)
 		return self
 
@@ -2011,7 +2013,7 @@ class OperationRest(ChildProduction):
 
 	_name: Optional[OperationName]
 	_open_paren: Symbol
-	_arguments: Optional["ArgumentList"]
+	_arguments: Optional[ArgumentList]
 	_close_paren: Symbol
 	_ignore: Optional[Ignore]
 
@@ -2045,7 +2047,7 @@ class OperationRest(ChildProduction):
 		return self._name.name if (self._name) else None
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self._arguments
 
 	@property
@@ -2057,7 +2059,7 @@ class OperationRest(ChildProduction):
 		output += str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 		return output + (str(self._ignore) if (self._ignore) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self._name):
 			self._name.define_markup(generator)
 		generator.add_text(self._open_paren)
@@ -2134,7 +2136,7 @@ class Iterable(ChildProduction):
 		return '__iterable__'
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	def _str(self) -> str:
@@ -2145,7 +2147,7 @@ class Iterable(ChildProduction):
 			output += str(self.key_type) + str(self._comma) + str(self.value_type)
 		return output + str(self._close_type)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._iterable.define_markup(generator)
 		generator.add_text(self._open_type)
 		if (self.type):
@@ -2183,7 +2185,7 @@ class AsyncIterable(ChildProduction):
 	value_type: Optional[TypeWithExtendedAttributes]
 	_close_type: Symbol
 	_open_paren: Optional[Symbol]
-	_arguments: Optional["ArgumentList"]
+	_arguments: Optional[ArgumentList]
 	_close_paren: Optional[Symbol]
 
 	@classmethod
@@ -2244,7 +2246,7 @@ class AsyncIterable(ChildProduction):
 		return '__async_iterable__'
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self._arguments
 
 	def _str(self) -> str:
@@ -2258,7 +2260,7 @@ class AsyncIterable(ChildProduction):
 			output += str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 		return output
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._async.define_markup(generator)
 		self._iterable.define_markup(generator)
 		generator.add_text(self._open_type)
@@ -2336,7 +2338,7 @@ class Maplike(ChildProduction):
 		return '__maplike__'
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	def _str(self) -> str:
@@ -2344,7 +2346,7 @@ class Maplike(ChildProduction):
 		output += str(self._maplike) + str(self._open_type) + str(self.key_type) + str(self._comma)
 		return output + str(self.value_type) + str(self._close_type)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.readonly):
 			self.readonly.define_markup(generator)
 		self._maplike.define_markup(generator)
@@ -2404,14 +2406,14 @@ class Setlike(ChildProduction):
 		return '__setlike__'
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return None
 
 	def _str(self) -> str:
 		output = str(self.readonly) if (self.readonly) else ''
 		return output + str(self._setlike) + str(self._open_type) + str(self.type) + str(self._close_type)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self.readonly):
 			self.readonly.define_markup(generator)
 		self._setlike.define_markup(generator)
@@ -2465,7 +2467,7 @@ class SpecialOperation(ChildProduction):
 		return self.operation.name if (self.operation.name) else ('__' + _name(self.specials[0]) + '__')
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.operation.arguments
 
 	@property
@@ -2485,7 +2487,7 @@ class SpecialOperation(ChildProduction):
 		output = ''.join([str(special) for special in self.specials])
 		return output + str(self.return_type) + str(self.operation)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		for special in self.specials:
 			special.define_markup(generator)
 		generator.add_type(self.return_type)
@@ -2529,7 +2531,7 @@ class Operation(ChildProduction):
 		return self.operation.name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.operation.arguments
 
 	@property
@@ -2548,7 +2550,7 @@ class Operation(ChildProduction):
 	def _str(self) -> str:
 		return str(self.return_type) + str(self.operation)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_type(self.return_type)
 		return self.operation._define_markup(generator)
 
@@ -2609,7 +2611,7 @@ class Stringifier(ChildProduction):
 		return self.attribute.name if (self.attribute and self.attribute.name) else '__stringifier__'
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.operation.arguments if (self.operation) else None
 
 	@property
@@ -2635,7 +2637,7 @@ class Stringifier(ChildProduction):
 		output += (str(self.return_type) + str(self.operation)) if (self.operation) else ''
 		return output + (str(self.attribute) if (self.attribute) else '')
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._stringifier.define_markup(generator)
 		if (self.operation):
 			generator.add_type(self.return_type)
@@ -2782,7 +2784,7 @@ class StaticMember(ChildProduction):
 		return self.operation.name if (self.operation) else cast(AttributeRest, self.attribute).name
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self.operation.arguments if (self.operation) else None
 
 	@property
@@ -2809,7 +2811,7 @@ class StaticMember(ChildProduction):
 			return output + str(self.return_type) + str(self.operation)
 		return output + str(self.attribute)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		self._static.define_markup(generator)
 		if (self.operation):
 			generator.add_type(self.return_type)
@@ -2833,7 +2835,7 @@ class Constructor(ChildProduction):
 
 	_constructor: Identifier
 	_open_paren: Symbol
-	_arguments: Optional["ArgumentList"]
+	_arguments: Optional[ArgumentList]
 	_close_paren: Symbol
 
 	@classmethod
@@ -2868,7 +2870,7 @@ class Constructor(ChildProduction):
 		return False
 
 	@property
-	def arguments(self) -> Optional["ArgumentList"]:
+	def arguments(self) -> Optional[ArgumentList]:
 		return self._arguments
 
 	@property
@@ -2892,7 +2894,7 @@ class Constructor(ChildProduction):
 		output = self.name if (self.name) else ''
 		return output + str(self._open_paren) + (str(self._arguments) if (self._arguments) else '') + str(self._close_paren)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		if (self._constructor):
 			self._constructor.define_markup(generator)
 		generator.add_text(self._open_paren)
@@ -2945,7 +2947,7 @@ class ExtendedAttributeList(ChildProduction):
 	def __len__(self) -> int:
 		return len(self.attributes)
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		if (isinstance(key, str)):
 			for attribute in self.attributes:
 				if (key == attribute.name):
@@ -2961,19 +2963,19 @@ class ExtendedAttributeList(ChildProduction):
 			return False
 		return (key in self.attributes)
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		return iter(self.attributes)
 
 	def keys(self) -> Sequence[str]:
 		return [attribute.name for attribute in self.attributes if (attribute.name)]
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		return [attribute for attribute in self.attributes if (attribute.name)]
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		return [(attribute.name, attribute) for attribute in self.attributes if (attribute.name)]
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		try:
 			return self[key]
 		except IndexError:
@@ -2984,7 +2986,7 @@ class ExtendedAttributeList(ChildProduction):
 		output += ''.join([str(attribute) + str(comma) for attribute, comma in itertools.zip_longest(self.attributes, self._commas, fillvalue='')])
 		return output + str(self._close_bracket)
 
-	def _define_markup(self, generator: "MarkupGenerator") -> Production:
+	def _define_markup(self, generator: MarkupGenerator) -> Production:
 		generator.add_text(self._open_bracket)
 		for attribute, comma in itertools.zip_longest(self.attributes, self._commas, fillvalue=''):
 			attribute.define_markup(generator)

--- a/widlparser/protocols.py
+++ b/widlparser/protocols.py
@@ -17,7 +17,7 @@ from typing import Iterator, List, Optional, Sequence, Tuple, Union, TYPE_CHECKI
 
 from typing_extensions import Protocol
 
-if TYPE_CHECKING:
+if (TYPE_CHECKING):
 	from .constructs import Construct
 
 

--- a/widlparser/protocols.py
+++ b/widlparser/protocols.py
@@ -11,6 +11,8 @@
 #
 """Protocol definitions."""
 
+from __future__ import annotations
+
 from typing import Iterator, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 from typing_extensions import Protocol
@@ -22,10 +24,10 @@ if TYPE_CHECKING:
 class SymbolTable(Protocol):
 	"""Protocol for symbol capture and lookup."""
 
-	def add_type(self, type: "Construct") -> None:
+	def add_type(self, type: Construct) -> None:
 		...
 
-	def get_type(self, name: str) -> Optional["Construct"]:
+	def get_type(self, name: str) -> Optional[Construct]:
 		...
 
 
@@ -35,59 +37,59 @@ class ConstructMap(Protocol):
 	def __len__(self) -> int:
 		...
 
-	def __getitem__(self, key: Union[str, int]) -> "Construct":
+	def __getitem__(self, key: Union[str, int]) -> Construct:
 		...
 
 	def __contains__(self, key: Union[str, int]) -> bool:
 		...
 
-	def __iter__(self) -> Iterator["Construct"]:
+	def __iter__(self) -> Iterator[Construct]:
 		...
 
 	def keys(self) -> Sequence[str]:
 		...
 
-	def values(self) -> Sequence["Construct"]:
+	def values(self) -> Sequence[Construct]:
 		...
 
-	def items(self) -> Sequence[Tuple[str, "Construct"]]:
+	def items(self) -> Sequence[Tuple[str, Construct]]:
 		...
 
-	def get(self, key: Union[str, int]) -> Optional["Construct"]:
+	def get(self, key: Union[str, int]) -> Optional[Construct]:
 		...
 
 
 class Marker(Protocol):
 	"""Protocol to provide markup."""
 
-	def markup_construct(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_construct(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_primitive_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_primitive_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_buffer_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_buffer_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_string_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_string_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_object_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_object_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_type_name(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_type_name(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_name(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_name(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_keyword(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_keyword(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_enum_value(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
+	def markup_enum_value(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
 		...
 
 	def encode(self, text: str) -> str:
@@ -97,34 +99,34 @@ class Marker(Protocol):
 class LegacyMarker(Protocol):
 	"""Protocol to provide markup."""
 
-	def markupConstruct(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupConstruct(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupPrimitiveType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupPrimitiveType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupBufferType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupBufferType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupStringType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupStringType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupObjectType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupObjectType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupTypeName(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupTypeName(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupName(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupName(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupKeyword(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupKeyword(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupEnumValue(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupEnumValue(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
 	def encode(self, text: str) -> str:

--- a/widlparser/protocols.py
+++ b/widlparser/protocols.py
@@ -13,7 +13,7 @@
 
 from __future__ import annotations
 
-from typing import Iterator, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import Iterator, Optional, Sequence, TYPE_CHECKING, Tuple, Union
 
 from typing_extensions import Protocol
 

--- a/widlparser/protocols.py
+++ b/widlparser/protocols.py
@@ -11,84 +11,21 @@
 #
 """Protocol definitions."""
 
-from typing import Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Iterator, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+	from .constructs import Construct
 
 
 class SymbolTable(Protocol):
 	"""Protocol for symbol capture and lookup."""
 
-	def add_type(self, type: 'Construct') -> None:
+	def add_type(self, type: "Construct") -> None:
 		...
 
-	def get_type(self, name: str) -> Optional['Construct']:
-		...
-
-
-class Production(Protocol):
-	"""Protocol for all productions."""
-
-	leading_space: str
-	semicolon: Union[str, 'Production']
-	trailing_space: str
-
-	@property
-	def tail(self) -> str:
-		...
-
-	def __str__(self) -> str:
-		...
-
-	def _define_markup(self, generator: 'MarkupGenerator') -> 'Production':
-		...
-
-	def define_markup(self, generator: 'MarkupGenerator') -> None:
-		...
-
-
-class ChildProduction(Protocol):
-	"""Protocol for productions that have parents."""
-
-	@property
-	def idl_type(self) -> str:
-		...
-
-	@property
-	def name(self) -> Optional[str]:
-		...
-
-	@property
-	def normal_name(self) -> Optional[str]:
-		...
-
-	@property
-	def full_name(self) -> Optional[str]:
-		...
-
-	def _define_markup(self, generator: 'MarkupGenerator') -> 'Production':
-		...
-
-	def define_markup(self, generator: 'MarkupGenerator') -> None:
-		...
-
-	@property
-	def method_name(self) -> Optional[str]:
-		...
-
-	@property
-	def method_names(self) -> List[str]:
-		...
-
-	@property
-	def arguments(self) -> Optional['ArgumentList']:
-		...
-
-	@property
-	def symbol_table(self) -> Optional[SymbolTable]:
-		...
-
-	def __str__(self) -> str:
+	def get_type(self, name: str) -> Optional["Construct"]:
 		...
 
 
@@ -98,205 +35,59 @@ class ConstructMap(Protocol):
 	def __len__(self) -> int:
 		...
 
-	def __getitem__(self, key: Union[str, int]) -> 'Construct':
+	def __getitem__(self, key: Union[str, int]) -> "Construct":
 		...
 
 	def __contains__(self, key: Union[str, int]) -> bool:
 		...
 
-	def __iter__(self) -> Iterator['Construct']:
+	def __iter__(self) -> Iterator["Construct"]:
 		...
 
 	def keys(self) -> Sequence[str]:
 		...
 
-	def values(self) -> Sequence['Construct']:
+	def values(self) -> Sequence["Construct"]:
 		...
 
-	def items(self) -> Sequence[Tuple[str, 'Construct']]:
+	def items(self) -> Sequence[Tuple[str, "Construct"]]:
 		...
 
-	def get(self, key: Union[str, int]) -> Optional['Construct']:
-		...
-
-
-class ArgumentList(Protocol):
-	"""List of arguments."""
-
-	def __len__(self) -> int:
-		...
-
-	def __getitem__(self, key: Union[str, int]) -> 'Construct':
-		...
-
-	def __contains__(self, key: Union[str, int]) -> bool:
-		...
-
-	def __iter__(self) -> Iterator['Construct']:
-		...
-
-	def keys(self) -> Sequence[str]:
-		...
-
-	def values(self) -> Sequence['Construct']:
-		...
-
-	def items(self) -> Sequence[Tuple[str, 'Construct']]:
-		...
-
-	def get(self, key: Union[str, int]) -> Optional['Construct']:
-		...
-
-	@property
-	def argument_names(self) -> Sequence[str]:
-		...
-
-	def matches_names(self, argument_names: Sequence[str]) -> bool:
-		...
-
-
-class Construct(Protocol):
-	"""Base class for high-level language constructs."""
-
-	@property
-	def idl_type(self) -> str:
-		...
-
-	@property
-	def name(self) -> Optional[str]:
-		...
-
-	@property
-	def normal_name(self) -> Optional[str]:
-		...
-
-	@property
-	def full_name(self) -> Optional[str]:
-		...
-
-	@property
-	def constructors(self) -> List['Construct']:
-		...
-
-	@property
-	def method_name(self) -> Optional[str]:
-		...
-
-	@property
-	def method_names(self) -> List[str]:
-		...
-
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		...
-
-	@property
-	def symbol_table(self) -> Optional[SymbolTable]:
-		...
-
-	@property
-	def extended_attributes(self) -> Optional[ConstructMap]:
-		...
-
-	def __bool__(self) -> bool:
-		...
-
-	def __len__(self) -> int:
-		...
-
-	def __getitem__(self, key: Union[str, int]) -> 'Construct':
-		...
-
-	def __contains__(self, key: Union[str, int]) -> bool:
-		...
-
-	def __iter__(self) -> Iterator['Construct']:
-		...
-
-	def __reversed__(self) -> Iterator['Construct']:
-		...
-
-	def keys(self) -> Sequence[str]:
-		...
-
-	def values(self) -> Sequence['Construct']:
-		...
-
-	def items(self) -> Sequence[Tuple[str, 'Construct']]:
-		...
-
-	def get(self, key: Union[str, int]) -> Optional['Construct']:
-		...
-
-	def find_member(self, name: str) -> Optional['Construct']:
-		...
-
-	def find_members(self, name: str) -> List['Construct']:
-		...
-
-	def find_method(self, name: str, argument_names: Sequence[str] = None) -> Optional['Construct']:
-		...
-
-	def find_methods(self, name: str, argument_names: Sequence[str] = None) -> List['Construct']:
-		...
-
-	def find_argument(self, name: str, search_members: bool = True) -> Optional['Construct']:
-		...
-
-	def find_arguments(self, name: str, search_members: bool = True) -> List['Construct']:
-		...
-
-	def matches_argument_names(self, argument_names: Sequence[str]) -> bool:
-		...
-
-	@property
-	def complexity_factor(self) -> int:
-		...
-
-	def __repr__(self) -> str:
-		...
-
-	def _define_markup(self, generator: 'MarkupGenerator') -> 'Production':
-		...
-
-	def define_markup(self, generator: 'MarkupGenerator') -> None:
-		...
-
-	def markup(self, marker: 'Marker') -> str:
+	def get(self, key: Union[str, int]) -> Optional["Construct"]:
 		...
 
 
 class Marker(Protocol):
 	"""Protocol to provide markup."""
 
-	def markup_construct(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_construct(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_primitive_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_primitive_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_buffer_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_buffer_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_string_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_string_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_object_type(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_object_type(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_type_name(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_type_name(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_name(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_name(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_keyword(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_keyword(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
-	def markup_enum_value(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:
+	def markup_enum_value(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:
 		...
 
 	def encode(self, text: str) -> str:
@@ -306,82 +97,35 @@ class Marker(Protocol):
 class LegacyMarker(Protocol):
 	"""Protocol to provide markup."""
 
-	def markupConstruct(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupConstruct(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupPrimitiveType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupPrimitiveType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupBufferType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupBufferType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupStringType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupStringType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupObjectType(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupObjectType(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupTypeName(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupTypeName(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupName(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupName(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupKeyword(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupKeyword(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
-	def markupEnumValue(self, text: str, construct: Construct) -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
+	def markupEnumValue(self, text: str, construct: "Construct") -> Tuple[Optional[str], Optional[str]]:  # noqa: N802
 		...
 
 	def encode(self, text: str) -> str:
-		...
-
-
-class MarkupGenerator(Protocol):
-	"""MarkupGenerator controls the markup process for a construct."""
-
-	def __init__(self, construct: Construct) -> None:
-		...
-
-	def add_generator(self, generator: 'MarkupGenerator') -> None:
-		...
-
-	def add_type(self, type: Optional[Production]) -> None:
-		...
-
-	def add_primitive_type(self, type: Optional[Production]) -> None:
-		...
-
-	def add_string_type(self, type: Optional[Production]) -> None:
-		...
-
-	def add_buffer_type(self, type: Optional[Production]) -> None:
-		...
-
-	def add_object_type(self, type: Optional[Production]) -> None:
-		...
-
-	def add_type_name(self, type_name: Optional[Union[str, Production]]) -> None:
-		...
-
-	def add_name(self, name: Optional[Union[str, Production]]) -> None:
-		...
-
-	def add_keyword(self, keyword: Optional[Union[str, Production]]) -> None:
-		...
-
-	def add_enum_value(self, enum_value: Optional[Union[str, Production]]) -> None:
-		...
-
-	def add_text(self, text: Optional[Union[str, Production]]) -> None:
-		...
-
-	@property
-	def text(self) -> str:
-		...
-
-	def markup(self, marker: Marker, construct: Construct = None) -> str:
 		...

--- a/widlparser/tokenizer.py
+++ b/widlparser/tokenizer.py
@@ -11,6 +11,8 @@
 #
 """Classes to convert input strings into tokens."""
 
+from __future__ import annotations
+
 import collections
 import enum
 import re


### PR DESCRIPTION
With Construct, Production, ChildProduction, etc all removed and references to the actual classes used instead, all of the mypy type failures disappear, since the subclassing relationships suddenly work again.  `test.py` also succeeds, so it looks like this is a no-op in behavior.

While I was here, I went ahead and added some necessary `cast()`s to `test.py`, so `mypy .` in the root works as well.