### PR TITLE
Make .parent non-Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ For 'method' Constructs, contains the normalized method name, otherwise the name
 
 **Construct.parent**
 
-The parent construct, or None if it is a top-level Construct in the source WebIDL.
+The parent construct, if it has one. Throws a KeyError if it is a top-level Construct in the source WebIDL.
+
+**Construct.has_parent**
+
+A bool specifying whether the construct has a parent or not (and thus whether `.parent` will throw or not when accessed.)
 
 **Construct.extended_attributes**
 

--- a/widlparser/__init__.py
+++ b/widlparser/__init__.py
@@ -47,7 +47,7 @@ from .productions import (
 	Attribute,
 	AttributeName,
 	AttributeRest,
-	ChildProduction,
+	ComplexProduction,
 	ConstType,
 	ConstValue,
 	Constructor,
@@ -111,7 +111,7 @@ __all__ = [
 
 	# productions
 	'Production',
-	'ChildProduction',
+	'ComplexProduction',
 	'String',
 	'Symbol',
 	'Integer',

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -1933,7 +1933,7 @@ class ExtendedAttributeArgList(Construct):
 	@property
 	def normal_name(self) -> Optional[str]:
 		if ('constructor' == self.idl_type):
-			return (str(self.parent.name) + '('
+			return (f'{self.parent.name}('
 			        + (', '.join(argument.name for argument in self._arguments if (argument.name)) if (self._arguments) else '') + ')')
 		return self.attribute
 

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -1873,7 +1873,7 @@ class ExtendedAttributeNoArgs(Construct):
 
 	@property
 	def normal_name(self) -> Optional[str]:
-		return (str(self.parent.name) + '()') if ('constructor' == self.idl_type) else self.attribute
+		return f'{self.parent.name}()' if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
 		return str(self._attribute)

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -71,7 +71,7 @@ class Construct(ComplexProduction):
 		"""Get symbol table."""
 		if (self._symbol_table is not None):
 			return self._symbol_table
-		return self.parent.symbol_table if (self.parent) else None
+		return self.parent.symbol_table if (self.has_parent) else None
 
 	@property
 	def extended_attributes(self) -> Optional[ExtendedAttributeList]:
@@ -1869,11 +1869,11 @@ class ExtendedAttributeNoArgs(Construct):
 
 	@property
 	def name(self) -> Optional[str]:
-		return cast(ComplexProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
+		return self.parent if ('constructor' == self.idl_type) else self.attribute
 
 	@property
 	def normal_name(self) -> Optional[str]:
-		return (str(cast(ComplexProduction, self.parent).name) + '()') if ('constructor' == self.idl_type) else self.attribute
+		return (str(self.parent.name) + '()') if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
 		return str(self._attribute)
@@ -1928,12 +1928,12 @@ class ExtendedAttributeArgList(Construct):
 
 	@property
 	def name(self) -> Optional[str]:
-		return cast(ComplexProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
+		return self.parent.name if ('constructor' == self.idl_type) else self.attribute
 
 	@property
 	def normal_name(self) -> Optional[str]:
 		if ('constructor' == self.idl_type):
-			return (str(cast(ComplexProduction, self.parent).name) + '('
+			return (str(self.parent.name) + '('
 			        + (', '.join(argument.name for argument in self._arguments if (argument.name)) if (self._arguments) else '') + ')')
 		return self.attribute
 

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -17,7 +17,7 @@ from typing import Any, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple
 
 from . import markup
 from . import protocols
-from .productions import (ArgumentList, ArgumentName, AsyncIterable, Attribute, ChildProduction, ConstType, ConstValue, Constructor, Default,
+from .productions import (ArgumentList, ArgumentName, AsyncIterable, Attribute, ComplexProduction, ConstType, ConstValue, Constructor, Default,
                           EnumValue, EnumValueList, ExtendedAttributeList, Identifier, IgnoreInOut, Inheritance, Iterable,
                           Maplike, MixinAttribute, Operation, Setlike, SpecialOperation, StaticMember, Stringifier, Symbol,
                           Type, TypeIdentifier, TypeIdentifiers, TypeWithExtendedAttributes)
@@ -32,7 +32,7 @@ def _name(thing: Any) -> str:
 	return getattr(thing, 'name', '') if (thing) else ''
 
 
-class Construct(ChildProduction):
+class Construct(ComplexProduction):
 	"""Base class for high-level language constructs."""
 
 	_symbol_table: Optional[protocols.SymbolTable]
@@ -43,9 +43,9 @@ class Construct(ChildProduction):
 		"""Check if construct is next in token stream."""
 		return ExtendedAttributeList.peek(tokens)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction = None, parse_extended_attributes: bool = True,
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction = None, parse_extended_attributes: bool = True,
 	             symbol_table: protocols.SymbolTable = None) -> None:
-		ChildProduction.__init__(self, tokens, parent)
+		ComplexProduction.__init__(self, tokens, parent)
 		self._symbol_table = symbol_table
 		self._extended_attributes = self._parse_extended_attributes(tokens, self) if (parse_extended_attributes) else None
 
@@ -211,7 +211,7 @@ class Const(Construct):
 						return tokens.pop_position(ConstValue.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Optional[Construct] = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, False, symbol_table=symbol_table)
 		self._const = Symbol(tokens, 'const')
 		self.type = ConstType(tokens)
@@ -419,7 +419,7 @@ class Argument(Construct):
 						return tokens.pop_position(True)
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction = None) -> None:
 		Construct.__init__(self, tokens, parent)
 		if (Symbol.peek(tokens, 'optional')):
 			self.optional = Symbol(tokens, 'optional')
@@ -487,7 +487,7 @@ class InterfaceMember(Construct):
 	| Iterable | Attribute | Maplike | Setlike
 	"""
 
-	member: ChildProduction
+	member: ComplexProduction
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -586,7 +586,7 @@ class MixinMember(Construct):
 	[ExtendedAttributes] Const | Operation | Stringifier | ReadOnly AttributeRest
 	"""
 
-	member: ChildProduction
+	member: ComplexProduction
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -1051,7 +1051,7 @@ class NamespaceMember(Construct):
 	[ExtendedAttributes] Operation | "readonly" Attribute | Const
 	"""
 
-	member: ChildProduction
+	member: ComplexProduction
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -1814,7 +1814,7 @@ class ExtendedAttributeUnknown(Construct):
 
 	tokens: List[Token]
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		skipped = tokens.seek_symbol((',', ']'))
 		self.tokens = skipped[:-1]
@@ -1854,7 +1854,7 @@ class ExtendedAttributeNoArgs(Construct):
 			return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._did_parse(tokens)
@@ -1869,11 +1869,11 @@ class ExtendedAttributeNoArgs(Construct):
 
 	@property
 	def name(self) -> Optional[str]:
-		return cast(ChildProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
+		return cast(ComplexProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
 
 	@property
 	def normal_name(self) -> Optional[str]:
-		return (str(cast(ChildProduction, self.parent).name) + '()') if ('constructor' == self.idl_type) else self.attribute
+		return (str(cast(ComplexProduction, self.parent).name) + '()') if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
 		return str(self._attribute)
@@ -1910,7 +1910,7 @@ class ExtendedAttributeArgList(Construct):
 					return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._open_paren = Symbol(tokens, '(')
@@ -1928,12 +1928,12 @@ class ExtendedAttributeArgList(Construct):
 
 	@property
 	def name(self) -> Optional[str]:
-		return cast(ChildProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
+		return cast(ComplexProduction, self.parent).name if ('constructor' == self.idl_type) else self.attribute
 
 	@property
 	def normal_name(self) -> Optional[str]:
 		if ('constructor' == self.idl_type):
-			return (str(cast(ChildProduction, self.parent).name) + '('
+			return (str(cast(ComplexProduction, self.parent).name) + '('
 			        + (', '.join(argument.name for argument in self._arguments if (argument.name)) if (self._arguments) else '') + ')')
 		return self.attribute
 
@@ -1975,7 +1975,7 @@ class ExtendedAttributeIdent(Construct):
 					return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._equals = Symbol(tokens, '=')
@@ -2043,7 +2043,7 @@ class ExtendedAttributeIdentList(Construct):
 							return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._equals = Symbol(tokens, '=')
@@ -2123,7 +2123,7 @@ class ExtendedAttributeNamedArgList(Construct):
 							return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._equals = Symbol(tokens, '=')
@@ -2206,7 +2206,7 @@ class ExtendedAttributeTypePair(Construct):
 								return tokens.pop_position((not token) or token.is_symbol((',', ']')))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._open_paren = Symbol(tokens, '(')
@@ -2267,7 +2267,7 @@ class ExtendedAttribute(Construct):
 		        or ExtendedAttributeIdentList.peek(tokens)
 		        or ExtendedAttributeIdent.peek(tokens))
 
-	def __init__(self, tokens: Tokenizer, parent: ChildProduction) -> None:
+	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		Construct.__init__(self, tokens, parent, False)
 		if (ExtendedAttributeNamedArgList.peek(tokens)):
 			self.attribute = ExtendedAttributeNamedArgList(tokens, parent)

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -211,7 +211,7 @@ class Const(Construct):
 						return tokens.pop_position(ConstValue.peek(tokens))
 		return tokens.pop_position(False)
 
-	def __init__(self, tokens: Tokenizer, parent: Optional[Construct] = None, symbol_table: protocols.SymbolTable = None) -> None:
+	def __init__(self, tokens: Tokenizer, parent: Construct = None, symbol_table: protocols.SymbolTable = None) -> None:
 		Construct.__init__(self, tokens, parent, False, symbol_table=symbol_table)
 		self._const = Symbol(tokens, 'const')
 		self.type = ConstType(tokens)

--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -1869,7 +1869,7 @@ class ExtendedAttributeNoArgs(Construct):
 
 	@property
 	def name(self) -> Optional[str]:
-		return self.parent if ('constructor' == self.idl_type) else self.attribute
+		return self.parent.name if ('constructor' == self.idl_type) else self.attribute
 
 	@property
 	def normal_name(self) -> Optional[str]:

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -18,6 +18,7 @@ import re
 from typing import Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from . import constructs
+from . import productions
 from . import markup
 from . import protocols
 from . import tokenizer
@@ -270,8 +271,8 @@ class Parser(object):
 		match = re.match(r'(.*)\((.*)\)(.*)', method_text)
 		if (match):
 			tokens = tokenizer.Tokenizer(match.group(2))
-			if (constructs.ArgumentList.peek(tokens)):
-				arguments = constructs.ArgumentList(tokens, None)
+			if (productions.ArgumentList.peek(tokens)):
+				arguments = productions.ArgumentList(tokens, None)
 				return match.group(1).strip() + '(' + arguments.argument_names[0] + ')'
 			name = match.group(1).strip() + match.group(3)
 			argument_names = [argument.strip() for argument in match.group(2).split(',')]
@@ -304,8 +305,8 @@ class Parser(object):
 		match = re.match(r'(.*)\((.*)\)(.*)', method_text)
 		if (match):
 			tokens = tokenizer.Tokenizer(match.group(2))
-			if (constructs.ArgumentList.peek(tokens)):
-				arguments = constructs.ArgumentList(tokens, None)
+			if (productions.ArgumentList.peek(tokens)):
+				arguments = productions.ArgumentList(tokens, None)
 				return [match.group(1).strip() + '(' + argument_name + ')' for argument_name in arguments.argument_names]
 			name = match.group(1).strip() + match.group(3)
 			argument_names = [argument.strip() for argument in match.group(2).split(',')]

--- a/widlparser/parser.py
+++ b/widlparser/parser.py
@@ -18,8 +18,8 @@ import re
 from typing import Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from . import constructs
-from . import productions
 from . import markup
+from . import productions
 from . import protocols
 from . import tokenizer
 

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -124,7 +124,7 @@ class ComplexProduction(Production):
 		raise KeyError()
 
 	@parent.setter
-	def parent(self, parent: ComplexProduction) -> None:
+	def parent(self, parent: Optional[ComplexProduction]) -> None:
 		self._parent = parent
 
 	@property

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -105,9 +105,10 @@ class Production(object):
 
 class ComplexProduction(Production):
 	"""
-		Base class for more complex productions;
-		things that can have names, parents, etc.
-		Also, all Constructs.
+	Base class for more complex productions.
+
+	Things that can have names, parents, etc.,
+	including all Constructs.
 	"""
 
 	_parent: Optional[ComplexProduction]
@@ -127,14 +128,14 @@ class ComplexProduction(Production):
 		self._parent = parent
 
 	@property
-	def hasParent(self) -> bool:
+	def has_parent(self) -> bool:
 		return self._parent is not None
 
 	@property
 	def full_name(self) -> Optional[str]:
 		if (not self.normal_name):
 			return None
-		return self.parent.full_name + '/' + self.normal_name if (self.hasParent and self.parent.full_name) else self.normal_name
+		return self.parent.full_name + '/' + self.normal_name if (self.has_parent and self.parent.full_name) else self.normal_name
 
 	@property
 	def normal_name(self) -> Optional[str]:

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -129,7 +129,7 @@ class ComplexProduction(Production):
 
 	@property
 	def has_parent(self) -> bool:
-		return self._parent is not None
+		return (self._parent is not None)
 
 	@property
 	def full_name(self) -> Optional[str]:

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -155,7 +155,7 @@ class ComplexProduction(Production):
 
 	@property
 	def symbol_table(self) -> Optional[protocols.SymbolTable]:
-		return self.parent.symbol_table if (self.parent) else None
+		return self.parent.symbol_table if (self.has_parent) else None
 
 
 class String(Production):

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -110,17 +110,21 @@ class ComplexProduction(Production):
 		Also, all Constructs.
 	"""
 
-	_parent: Optional[ChildProduction]
+	_parent: Optional[ComplexProduction]
 
 	def __init__(self, tokens: Tokenizer, parent: Optional[ComplexProduction]) -> None:
 		Production.__init__(self, tokens)
 		self._parent = parent
 
 	@property
-	def parent(self) -> ChildProduction:
+	def parent(self) -> ComplexProduction:
 		if self._parent is not None:
 			return self._parent
 		raise KeyError()
+
+	@parent.setter
+	def parent(self, parent: ComplexProduction) -> None:
+		self._parent = parent
 
 	@property
 	def hasParent(self) -> bool:


### PR DESCRIPTION
The first and third of these commits are editorial; they can be reversed if necessary. The first is a simple correctness issue, the third makes the name more sensical since "ChildProduction" is used for several things that *never* have a parent.

The second is the juicy one - I switch to storing parent information in a `_parent` attribute, and then expose `parent` as a property that reflects `_parent`, but throws (with a `KeyError`, for consistency with dicts) if the construct doesn't have a parent. I also expose a `hasParent` property to allow for testing this without requiring a try block.