### PR TITLE
Make ArgumentList non-optional when possible.

### DIFF
--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -1552,7 +1552,7 @@ class Callback(Construct):
 			self._equals = Symbol(tokens, '=')
 			self.return_type = Type(tokens, self)
 			self._open_paren = Symbol(tokens, '(')
-			self._arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
+			self._arguments = ArgumentList(tokens, self)
 			self._close_paren = Symbol(tokens, ')')
 			self.interface = None
 			self._consume_semicolon(tokens)
@@ -1896,7 +1896,7 @@ class ExtendedAttributeArgList(Construct):
 
 	_attribute: Identifier
 	_open_paren: Symbol
-	_arguments: Optional[ArgumentList]
+	_arguments: ArgumentList
 	_close_paren: Symbol
 
 	@classmethod
@@ -1914,7 +1914,7 @@ class ExtendedAttributeArgList(Construct):
 		Construct.__init__(self, tokens, parent, False)
 		self._attribute = Identifier(tokens)
 		self._open_paren = Symbol(tokens, '(')
-		self._arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
+		self._arguments = ArgumentList(tokens, self)
 		self._close_paren = Symbol(tokens, ')')
 		self._did_parse(tokens)
 
@@ -1950,7 +1950,7 @@ class ExtendedAttributeArgList(Construct):
 
 	def __repr__(self) -> str:
 		return ('[ExtendedAttributeArgList: ' + repr(self._attribute)
-		        + ' [arguments: ' + (repr(self._arguments) if (self._arguments) else '') + ']]')
+		        + ' [arguments: ' + repr(self._arguments) + ']]')
 
 
 class ExtendedAttributeIdent(Construct):
@@ -2107,7 +2107,7 @@ class ExtendedAttributeNamedArgList(Construct):
 	_equals: Symbol
 	_value: TypeIdentifier
 	_open_paren: Symbol
-	_arguments: Optional[ArgumentList]
+	_arguments: ArgumentList
 	_close_paren: Symbol
 
 	@classmethod
@@ -2129,7 +2129,7 @@ class ExtendedAttributeNamedArgList(Construct):
 		self._equals = Symbol(tokens, '=')
 		self._value = TypeIdentifier(tokens)
 		self._open_paren = Symbol(tokens, '(')
-		self._arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
+		self._arguments = ArgumentList(tokens, self)
 		self._close_paren = Symbol(tokens, ')')
 		self._did_parse(tokens)
 
@@ -2156,7 +2156,7 @@ class ExtendedAttributeNamedArgList(Construct):
 		return self.attribute
 
 	@property
-	def arguments(self) -> Optional[ArgumentList]:
+	def arguments(self) -> ArgumentList:
 		return self._arguments
 
 	def _str(self) -> str:
@@ -2175,7 +2175,7 @@ class ExtendedAttributeNamedArgList(Construct):
 
 	def __repr__(self) -> str:
 		return ('[ExtendedAttributeNamedArgList: ' + repr(self._attribute) + ' [value: ' + repr(self._value) + ']'
-		        + ' [arguments: ' + (repr(self._arguments) if (self._arguments) else '') + ']]')
+		        + ' [arguments: ' + repr(self._arguments) + ']]')
 
 
 class ExtendedAttributeTypePair(Construct):

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1625,6 +1625,8 @@ class ArgumentList(Production):
 		Production.__init__(self, tokens)
 		self.arguments = []
 		self._commas = []
+		if (not ArgumentList.peek(tokens)):
+			return
 		self.arguments.append(constructs.Argument(tokens, parent))
 		token = tokens.sneak_peek()
 		while (token and token.is_symbol(',')):
@@ -1655,7 +1657,9 @@ class ArgumentList(Production):
 
 	@property
 	def name(self) -> Optional[str]:
-		return self.arguments[0].name
+		if (self.arguments):
+			return self.arguments[0].name
+		return None
 
 	@property   # get all possible variants of argument names
 	def argument_names(self) -> Sequence[str]:
@@ -2013,7 +2017,7 @@ class OperationRest(ChildProduction):
 
 	_name: Optional[OperationName]
 	_open_paren: Symbol
-	_arguments: Optional[ArgumentList]
+	_arguments: ArgumentList
 	_close_paren: Symbol
 	_ignore: Optional[Ignore]
 
@@ -2032,7 +2036,7 @@ class OperationRest(ChildProduction):
 		ChildProduction.__init__(self, tokens, parent)
 		self._name = OperationName(tokens) if (OperationName.peek(tokens)) else None
 		self._open_paren = Symbol(tokens, '(')
-		self._arguments = ArgumentList(tokens, parent) if (ArgumentList.peek(tokens)) else None
+		self._arguments = ArgumentList(tokens, parent)
 		self._close_paren = Symbol(tokens, ')')
 		self._ignore = Ignore(tokens) if (Ignore.peek(tokens)) else None
 		self._consume_semicolon(tokens)
@@ -2047,7 +2051,7 @@ class OperationRest(ChildProduction):
 		return self._name.name if (self._name) else None
 
 	@property
-	def arguments(self) -> Optional[ArgumentList]:
+	def arguments(self) -> ArgumentList:
 		return self._arguments
 
 	@property
@@ -2073,7 +2077,7 @@ class OperationRest(ChildProduction):
 	def __repr__(self) -> str:
 		output = '[OperationRest: '
 		output += ('[name: ' + repr(self._name) + '] ') if (self._name) else ''
-		return output + '[ArgumentList: ' + (repr(self._arguments) if (self._arguments) else '') + ']]'
+		return output + '[ArgumentList: ' + repr(self._arguments) + ']]'
 
 
 class Iterable(ChildProduction):
@@ -2228,7 +2232,7 @@ class AsyncIterable(ChildProduction):
 
 		if (Symbol.peek(tokens, '(')):
 			self._open_paren = Symbol(tokens, '(')
-			self._arguments = ArgumentList(tokens, parent) if (ArgumentList.peek(tokens)) else None
+			self._arguments = ArgumentList(tokens, parent)
 			self._close_paren = Symbol(tokens, ')')
 		else:
 			self._open_paren = None
@@ -2467,7 +2471,7 @@ class SpecialOperation(ChildProduction):
 		return self.operation.name if (self.operation.name) else ('__' + _name(self.specials[0]) + '__')
 
 	@property
-	def arguments(self) -> Optional[ArgumentList]:
+	def arguments(self) -> ArgumentList:
 		return self.operation.arguments
 
 	@property
@@ -2531,7 +2535,7 @@ class Operation(ChildProduction):
 		return self.operation.name
 
 	@property
-	def arguments(self) -> Optional[ArgumentList]:
+	def arguments(self) -> ArgumentList:
 		return self.operation.arguments
 
 	@property
@@ -2835,7 +2839,7 @@ class Constructor(ChildProduction):
 
 	_constructor: Identifier
 	_open_paren: Symbol
-	_arguments: Optional[ArgumentList]
+	_arguments: ArgumentList
 	_close_paren: Symbol
 
 	@classmethod
@@ -2852,7 +2856,7 @@ class Constructor(ChildProduction):
 		ChildProduction.__init__(self, tokens, parent)
 		self._constructor = Identifier(tokens)  # treat 'constructor' as a name
 		self._open_paren = Symbol(tokens, '(')
-		self._arguments = ArgumentList(tokens, self) if (ArgumentList.peek(tokens)) else None
+		self._arguments = ArgumentList(tokens, self)
 		self._close_paren = Symbol(tokens, ')')
 		self._consume_semicolon(tokens)
 		self._did_parse(tokens)
@@ -2870,7 +2874,7 @@ class Constructor(ChildProduction):
 		return False
 
 	@property
-	def arguments(self) -> Optional[ArgumentList]:
+	def arguments(self) -> ArgumentList:
 		return self._arguments
 
 	@property
@@ -2905,7 +2909,7 @@ class Constructor(ChildProduction):
 
 	def __repr__(self) -> str:
 		output = '[Constructor: '
-		return output + '[ArgumentList: ' + (repr(self._arguments) if (self._arguments) else '') + ']]'
+		return output + '[ArgumentList: ' + repr(self._arguments) + ']]'
 
 
 class ExtendedAttributeList(ChildProduction):

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1687,7 +1687,7 @@ class ArgumentList(Production):
 	def __len__(self) -> int:
 		return len(self.arguments)
 
-	def __getitem__(self, key: Union[str, int]) -> Construct:
+	def __getitem__(self, key: Union[str, int]) -> Argument:
 		if (isinstance(key, str)):
 			for argument in self.arguments:
 				if (argument.name == key):
@@ -1709,13 +1709,13 @@ class ArgumentList(Production):
 	def keys(self) -> Sequence[str]:
 		return [argument.name for argument in self.arguments if (argument.name)]
 
-	def values(self) -> Sequence[Construct]:
+	def values(self) -> Sequence[Argument]:
 		return [argument for argument in self.arguments if (argument.name)]
 
-	def items(self) -> Sequence[Tuple[str, Construct]]:
+	def items(self) -> Sequence[Tuple[str, Argument]]:
 		return [(argument.name, argument) for argument in self.arguments if (argument.name)]
 
-	def get(self, key: Union[str, int]) -> Optional[Construct]:
+	def get(self, key: Union[str, int]) -> Optional[Argument]:
 		try:
 			return self[key]
 		except IndexError:

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -23,7 +23,7 @@ from .tokenizer import Token, Tokenizer
 
 if (TYPE_CHECKING):
 	from .markup import MarkupGenerator
-	from .constructs import Construct
+	from .constructs import Construct, Argument
 
 
 def _name(thing: Any) -> str:
@@ -1607,7 +1607,7 @@ class ArgumentList(Production):
 	Argument ["," Argument]...
 	"""
 
-	arguments: List['constructs.Argument']
+	arguments: List[Argument]
 	_commas: List[Symbol]
 
 	@classmethod

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1901,10 +1901,6 @@ class MixinAttribute(ChildProduction):
 	def name(self) -> Optional[str]:
 		return self.attribute.name
 
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		return None
-
 	def _str(self) -> str:
 		return str(self.attribute)
 
@@ -1950,10 +1946,6 @@ class Attribute(ChildProduction):
 	@property
 	def name(self) -> Optional[str]:
 		return self.attribute.name
-
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		return None
 
 	def _str(self) -> str:
 		output = str(self.inherit) if (self.inherit) else ''
@@ -2138,10 +2130,6 @@ class Iterable(ChildProduction):
 	@property
 	def name(self) -> Optional[str]:
 		return '__iterable__'
-
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		return None
 
 	def _str(self) -> str:
 		output = str(self._iterable) + str(self._open_type)
@@ -2341,10 +2329,6 @@ class Maplike(ChildProduction):
 	def name(self) -> Optional[str]:
 		return '__maplike__'
 
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		return None
-
 	def _str(self) -> str:
 		output = str(self.readonly) if (self.readonly) else ''
 		output += str(self._maplike) + str(self._open_type) + str(self.key_type) + str(self._comma)
@@ -2408,10 +2392,6 @@ class Setlike(ChildProduction):
 	@property
 	def name(self) -> Optional[str]:
 		return '__setlike__'
-
-	@property
-	def arguments(self) -> Optional[ArgumentList]:
-		return None
 
 	def _str(self) -> str:
 		output = str(self.readonly) if (self.readonly) else ''


### PR DESCRIPTION
First commit is editorial.

Second commit is the meat: 
1. allow ArgumentList to parse an empty list of arguments
2. fix every place that can have arguments. constructs that *always* have arguments lose the optionality from their .arguments property; constucts that can optionally have arguments (like stringifiers) keep it, but properly host an ArgumentList if they *do* have an argument list, even if it's empty.

Third just fixes a nit I ran into - the ArgumentList retrieval/iterator methods are overly generic in their return types. ArgumentLists only hold Arguments.

Fourth removes several no-op arguments properties, since those classes were getting the exact same method from ChildProduction anyway.