### PR TITLE
Trailing comma on EnumValueList isn't a legacy ignored thing. Fixes #75

### DIFF
--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -730,7 +730,6 @@ class EnumValueList(Production):
 				self._commas.append(Symbol(tokens, ','))
 				token = tokens.sneak_peek()
 				if ((not token) or token.is_symbol('}')):
-					tokens.did_ignore(',')
 					break
 				continue
 			break


### PR DESCRIPTION
The only other uses of `did_ignore()` occur in definitely-ignored legacy constructs, which widlparser accepts so it can successfully parse some old legacy IDL that's not going to get fixed. But trailing commas in EnumValueList don't fit this pattern at all, they're just a normal allowed thing by the grammar.