### PR TITLE
Remove optionality from name on all reasonable constructs.

### DIFF
--- a/widlparser/constructs.py
+++ b/widlparser/constructs.py
@@ -55,11 +55,7 @@ class Construct(ComplexProduction):
 	@property
 	def idl_type(self) -> str:
 		"""Get construct type."""
-		raise NotImplementedError   # subclasses must override
-
-	@property
-	def name(self) -> Optional[str]:
-		return None
+		raise NotImplementedError()   # subclasses must override
 
 	@property
 	def constructors(self) -> List[Construct]:
@@ -227,7 +223,7 @@ class Const(Construct):
 		return 'const'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		"""Get name."""
 		return self._name.name
 
@@ -309,7 +305,7 @@ class Enum(Construct):
 		return 'enum'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -368,7 +364,7 @@ class Typedef(Construct):
 		return 'typedef'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -442,7 +438,7 @@ class Argument(Construct):
 		return 'argument'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -531,8 +527,8 @@ class InterfaceMember(Construct):
 		return self.member.idl_type
 
 	@property
-	def name(self) -> Optional[str]:
-		return self.member.name
+	def name(self) -> str:
+		return cast(str, self.member.name)
 
 	@property
 	def method_name(self) -> Optional[str]:
@@ -612,7 +608,8 @@ class MixinMember(Construct):
 		return self.member.idl_type
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
+		assert (self.member.name is not None)
 		return self.member.name
 
 	@property
@@ -748,7 +745,7 @@ class Interface(Construct):
 		return 'interface'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -923,7 +920,7 @@ class Mixin(Construct):
 		return 'interface'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -1077,8 +1074,8 @@ class NamespaceMember(Construct):
 		return self.member.idl_type
 
 	@property
-	def name(self) -> Optional[str]:
-		return self.member.name
+	def name(self) -> str:
+		return cast(str, self.member.name)
 
 	@property
 	def method_name(self) -> Optional[str]:
@@ -1176,7 +1173,7 @@ class Namespace(Construct):
 		return 'namespace'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -1326,7 +1323,7 @@ class DictionaryMember(Construct):
 		return 'dict-member'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -1409,7 +1406,7 @@ class Dictionary(Construct):
 		return 'dictionary'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -1576,7 +1573,7 @@ class Callback(Construct):
 		return 'callback'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
@@ -1731,11 +1728,11 @@ class ImplementsStatement(Construct):
 		return 'implements'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
-	def implements(self) -> Optional[str]:
+	def implements(self) -> str:
 		return self._implements.name
 
 	def _str(self) -> str:
@@ -1784,11 +1781,11 @@ class IncludesStatement(Construct):
 		return 'includes'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	@property
-	def includes(self) -> Optional[str]:
+	def includes(self) -> str:
 		return self._includes.name
 
 	def _str(self) -> str:
@@ -1826,8 +1823,12 @@ class ExtendedAttributeUnknown(Construct):
 		return 'extended-attribute'
 
 	@property
-	def name(self) -> Optional[str]:
-		return None
+	def name(self) -> str:
+		return ''
+
+	@property
+	def normal_name(self) -> str:
+		return ''
 
 	def _str(self) -> str:
 		return ''.join([str(token) for token in self.tokens])
@@ -1868,11 +1869,11 @@ class ExtendedAttributeNoArgs(Construct):
 		return _name(self._attribute)
 
 	@property
-	def name(self) -> Optional[str]:
-		return self.parent.name if ('constructor' == self.idl_type) else self.attribute
+	def name(self) -> str:
+		return str(self.parent.name) if ('constructor' == self.idl_type) else self.attribute
 
 	@property
-	def normal_name(self) -> Optional[str]:
+	def normal_name(self) -> str:
 		return f'{self.parent.name}()' if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
@@ -1927,11 +1928,11 @@ class ExtendedAttributeArgList(Construct):
 		return _name(self._attribute)
 
 	@property
-	def name(self) -> Optional[str]:
-		return self.parent.name if ('constructor' == self.idl_type) else self.attribute
+	def name(self) -> str:
+		return str(self.parent.name) if ('constructor' == self.idl_type) else self.attribute
 
 	@property
-	def normal_name(self) -> Optional[str]:
+	def normal_name(self) -> str:
 		if ('constructor' == self.idl_type):
 			return (f'{self.parent.name}('
 			        + (', '.join(argument.name for argument in self._arguments if (argument.name)) if (self._arguments) else '') + ')')
@@ -1995,11 +1996,11 @@ class ExtendedAttributeIdent(Construct):
 		return _name(self._value)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.value if ('constructor' == self.idl_type) else self.attribute
 
 	@property
-	def normal_name(self) -> Optional[str]:
+	def normal_name(self) -> str:
 		return (str(self.value) + '()') if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
@@ -2066,11 +2067,11 @@ class ExtendedAttributeIdentList(Construct):
 		return _name(self._value)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.value if ('constructor' == self.idl_type) else self.attribute
 
 	@property
-	def normal_name(self) -> Optional[str]:
+	def normal_name(self) -> str:
 		return (str(self.value) + '()') if ('constructor' == self.idl_type) else self.attribute
 
 	def _str(self) -> str:
@@ -2146,11 +2147,11 @@ class ExtendedAttributeNamedArgList(Construct):
 		return _name(self._value)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.value if ('constructor' == self.idl_type) else self.attribute
 
 	@property
-	def normal_name(self) -> Optional[str]:
+	def normal_name(self) -> str:
 		if ('constructor' == self.idl_type):
 			return self.value + '(' + (', '.join(argument.name for argument in self._arguments if (argument.name)) if (self._arguments) else '') + ')'
 		return self.attribute
@@ -2225,7 +2226,7 @@ class ExtendedAttributeTypePair(Construct):
 		return _name(self._attribute)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.attribute
 
 	def _str(self) -> str:
@@ -2256,7 +2257,7 @@ class ExtendedAttribute(Construct):
 	| ExtendedAttributeIdentList | ExtendedAttributeTypePair
 	"""
 
-	attribute: Construct
+	attribute: ExtendedAttributeType
 
 	@classmethod
 	def peek(cls, tokens: Tokenizer) -> bool:
@@ -2290,7 +2291,7 @@ class ExtendedAttribute(Construct):
 		return self.attribute.idl_type
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.attribute.name
 
 	@property
@@ -2328,3 +2329,14 @@ class ExtendedAttribute(Construct):
 
 	def __repr__(self) -> str:
 		return repr(self.attribute)
+
+
+ExtendedAttributeType = Union[
+	ExtendedAttributeNamedArgList,
+	ExtendedAttributeArgList,
+	ExtendedAttributeNoArgs,
+	ExtendedAttributeTypePair,
+	ExtendedAttributeIdentList,
+	ExtendedAttributeIdent,
+	ExtendedAttributeUnknown,
+]

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -513,7 +513,7 @@ class TypeIdentifier(Production):
 		self._did_parse(tokens, False)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name[1:] if ('_' == self._name[0]) else self._name
 
 	@property
@@ -1604,7 +1604,7 @@ class ArgumentName(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -1673,12 +1673,6 @@ class ArgumentList(Production):
 									break
 							else:
 								tokens.error('Dictionary argument "', argument.name, '" without required members must be marked optional')
-
-	@property
-	def name(self) -> Optional[str]:
-		if (self.arguments):
-			return self.arguments[0].name
-		return None
 
 	@property   # get all possible variants of argument names
 	def argument_names(self) -> Sequence[str]:
@@ -1777,7 +1771,7 @@ class Special(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name
 
 	def _str(self) -> str:
@@ -1814,7 +1808,7 @@ class AttributeName(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -1863,7 +1857,7 @@ class AttributeRest(ComplexProduction):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -1918,7 +1912,7 @@ class MixinAttribute(ComplexProduction):
 		return False
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.attribute.name
 
 	def _str(self) -> str:
@@ -1964,7 +1958,7 @@ class Attribute(ComplexProduction):
 		return False
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.attribute.name
 
 	def _str(self) -> str:
@@ -2005,7 +1999,7 @@ class OperationName(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -2059,8 +2053,8 @@ class OperationRest(ComplexProduction):
 		return 'method'
 
 	@property
-	def name(self) -> Optional[str]:
-		return self._name.name if (self._name) else None
+	def name(self) -> str:
+		return self._name.name if (self._name) else ''
 
 	@property
 	def arguments(self) -> ArgumentList:
@@ -2148,7 +2142,7 @@ class Iterable(ComplexProduction):
 		return 'iterable'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return '__iterable__'
 
 	def _str(self) -> str:
@@ -2254,7 +2248,7 @@ class AsyncIterable(ComplexProduction):
 		return 'async-iterable'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return '__async_iterable__'
 
 	@property
@@ -2346,7 +2340,7 @@ class Maplike(ComplexProduction):
 		return 'maplike'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return '__maplike__'
 
 	def _str(self) -> str:
@@ -2410,7 +2404,7 @@ class Setlike(ComplexProduction):
 		return 'setlike'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return '__setlike__'
 
 	def _str(self) -> str:
@@ -2467,7 +2461,7 @@ class SpecialOperation(ComplexProduction):
 		return 'method'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.operation.name if (self.operation.name) else ('__' + _name(self.specials[0]) + '__')
 
 	@property
@@ -2531,7 +2525,7 @@ class Operation(ComplexProduction):
 		return 'method'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.operation.name
 
 	@property
@@ -2609,7 +2603,7 @@ class Stringifier(ComplexProduction):
 		return True
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		if (self.operation):
 			return self.operation.name if (self.operation.name) else '__stringifier__'
 		return self.attribute.name if (self.attribute and self.attribute.name) else '__stringifier__'
@@ -2688,7 +2682,7 @@ class Identifiers(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -2728,7 +2722,7 @@ class TypeIdentifiers(Production):
 		self._did_parse(tokens)
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._name.name
 
 	def _str(self) -> str:
@@ -2784,7 +2778,7 @@ class StaticMember(ComplexProduction):
 		return False
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self.operation.name if (self.operation) else cast(AttributeRest, self.attribute).name
 
 	@property
@@ -2866,7 +2860,7 @@ class Constructor(ComplexProduction):
 		return 'method'
 
 	@property
-	def name(self) -> Optional[str]:
+	def name(self) -> str:
 		return self._constructor.name
 
 	@property


### PR DESCRIPTION
Despite virtually all constructs having a name, `name` was still marked as `Optional[str]` everywhere. This PR narrows that to `str` wherever possible, so I don't have to do lots of None-checking or casting when grabbing the names of things.  Some particular details:

* gave an unnamed OperationRest the empty string as a name, so it doesn't need to be Optional. 

	All the uses of OperationRest that *can* be unnamed just test if they're unnamed and substitute a more specific string, like `'__stringifier__'`; unfortunately methods, which are always named, don't have a more specific grammar construction, and so they get inconveniently lumped into here. The "am I unnamed" test just checks the name as a boolean, so empty string works great here.

* Similarly gave ExtendedAttributeUnknown an empty string as a name; it's a funky corner case that would otherwise infect ExtendedAttribute with an optional name even tho every *recognized* form of ExtendedAttribute has a name, and to avoid that you'd need to either always guard or always typecheck with one of the more specific subtypes, neither of which are useful to make authors do.

	Could replace with a `raise` or something, tho, if desired.

	Similarly, gave it an empty string `normal_name`, tho `normal_name` *is* often optional on other constructs. (Might be fixable, just didn't dive into it.)

	(Also added an `ExtendedAttributeType` alias that's a union of the specific subtypes, so `ExtendedAttribute` can properly narrow its `attribute` property and thus get good type-checking whenever it references that property.)

* Left the big general superclasses (`Construct`, `Production`, `ComplexProduction`) as having an optional name, as they *don't* have names and you really can't depend on things. Had to sprinkle a few casts around for things that can contain anything, like `NamespaceMember` or `InterfaceMember`.

* Deleted ArgumentList's `name` attribute; it was very odd in the first place (returning the name of its first arg when it had exactly 1 arg, but None if it had 0 or 2+ args).

* Explored fixing `type_name`(/`s`) as well (bunches of type-related classes that are either `None` despite having a reasonable type name or missing entirely), but I'm honestly not sure what it's meant to be used for in the first place - it doesn't look anything internal calls these. So I left them alone.