### PR TITLE
README.md fix typo in `pip install widlparser3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 
 Standard python package installation:
 
-    pip install widlparser3
+    pip install widlparser
 
 
 Usage


### PR DESCRIPTION
Typo in `pip install widlparser3`
Should be `pip install widlparser`