### PR TITLE
Allow required args after optional args. Fixes #79

### DIFF
--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1653,8 +1653,6 @@ class ArgumentList(Production):
 			if (len(self.arguments)):
 				if (self.arguments[-1].variadic):
 					tokens.error('Argument "', argument.name, '" not allowed to follow variadic argument "', self.arguments[-1].name, '"')
-				elif ((not self.arguments[-1].required) and argument.required):
-					tokens.error('Required argument "', argument.name, '" cannot follow optional argument "', self.arguments[-1].name, '"')
 			self.arguments.append(argument)
 			token = tokens.sneak_peek()
 		self._did_parse(tokens)


### PR DESCRIPTION
As stated in <https://github.com/whatwg/webidl/issues/1214>, this restriction only existed briefly in 2011-2013. Now it's just fine to have required after optional; you can trigger the optionality (and get the default value) by explicitly passing undefined.