### PR TITLE
Add support for parsing `async iterable<T>` type

### DIFF
--- a/test-expected.txt
+++ b/test-expected.txt
@@ -198,6 +198,12 @@ interface BigNumbers {
   const bigint biiig = 42;
 };
 
+typedef async iterable<DOMString[]> asynciterables;
+typedef async iterable<DOMString[]>? asynciterableses;
+interface Concat {
+  Promise<DOMString> concat(async iterable<DOMString> iter);
+};
+
 <<<
 IDL SYNTAX ERROR LINE: 3 - skipped: "serializer"
 
@@ -434,6 +440,11 @@ IDL SYNTAX ERROR LINE: 189 - skipped: "readonly setlike<DOMString>"
 [Interface: [name: BigNumbers] [members: 
   [Member: [Const: [ConstType: [PrimitiveType: bigint]][name: biiig] = [value: 42]]]
 ]]
+[Typedef: [TypeWithExtendedAttributes: [SingleType: [NonAnyType: [TypeWithExtendedAttributes: [SingleType: [NonAnyType: DOMString[TypeSuffix: [array] ]]]]]]] [name: asynciterables]]
+[Typedef: [TypeWithExtendedAttributes: [SingleType: [NonAnyType: [TypeWithExtendedAttributes: [SingleType: [NonAnyType: DOMString[TypeSuffix: [array] ]]]][null]]]] [name: asynciterableses]]
+[Interface: [name: Concat] [members: 
+  [Member: [Operation: [Type: [SingleType: [NonAnyType: [Promise] [Type: [SingleType: [NonAnyType: DOMString]]]]]] [OperationRest: [name: [OperationName: concat]] [ArgumentList: [Argument: [type: async iterable<DOMString> ] [name: [ArgumentName: iter]]]]]]]
+]]
 ]
 MARKED UP:
 <c dictionary><k>dictionary</k> <n>CSSFontFaceLoadEventInit</n> : <tn>EventInit</tn> { <c dict-member><t><k>sequence</k>&lt;<t><tn>CSSFontFaceRule</tn></t>&gt;</t> <n>fontfaces</n> = [ ];</c> };</c>
@@ -635,7 +646,13 @@ typedef   short    shorttype  = error this is;</c>
   <c const><k>const</k> <t><p><k>bigint</k></p></t> <n>biiig</n> = 42;</c>
 };</c>
 
-Complexity: 151
+<c typedef><k>typedef</k> <t><k>async</k> <k>iterable</k>&lt;<t><s><k>DOMString</k></s>[]</t>&gt;</t> <n>asynciterables</n>;</c>
+<c typedef><k>typedef</k> <t><k>async</k> <k>iterable</k>&lt;<t><s><k>DOMString</k></s>[]</t>&gt;?</t> <n>asynciterableses</n>;</c>
+<c interface><k>interface</k> <n>Concat</n> {
+  <c method><t><k>Promise</k>&lt;<t><s><k>DOMString</k></s></t>&gt;</t> <n>concat</n>(<c argument><t><k>async</k> <k>iterable</k>&lt;<t><s><k>DOMString</k></s></t>&gt;</t> <n>iter</n></c>);</c>
+};</c>
+
+Complexity: 155
 dictionary: CSSFontFaceLoadEventInit
     dict-member: fontfaces (fontfaces)
 interface: Simple
@@ -793,6 +810,10 @@ interface: Underscores
     method: includes(value) (includes)
 interface: BigNumbers
     const: biiig (biiig)
+typedef: asynciterables
+typedef: asynciterableses
+interface: Concat
+    method: concat(iter) (concat)
 FIND:
 callMe/round
 Foo/method(x, y, inf, ...fooArg)/y

--- a/test.py
+++ b/test.py
@@ -214,8 +214,6 @@ typedef foo barType;
 typedef foo [ ] [ ]  barTypes;
 typedef sequence<DOMString[]> sequins;
 typedef sequence<DOMString[]>? sequinses;
-typedef async iterable<DOMString[]> asynciterables;
-typedef async iterable<DOMString[]>? asynciterableses;
 typedef object obj;
 typedef (short or [Extended] double) union;
 typedef (short or sequence < DOMString [ ] ? [ ] > ? or DOMString[]?[] or unsigned long long or unrestricted double) craziness;
@@ -344,6 +342,12 @@ interface Underscores {
 };
 interface BigNumbers {
   const bigint biiig = 42;
+};
+
+typedef async iterable<DOMString[]> asynciterables;
+typedef async iterable<DOMString[]>? asynciterableses;
+interface Concat {
+  Promise<DOMString> concat(async iterable<DOMString> iter);
 };
 """
 #    idl = idl.replace(' ', '  ')

--- a/test.py
+++ b/test.py
@@ -214,6 +214,8 @@ typedef foo barType;
 typedef foo [ ] [ ]  barTypes;
 typedef sequence<DOMString[]> sequins;
 typedef sequence<DOMString[]>? sequinses;
+typedef async iterable<DOMString[]> asynciterables;
+typedef async iterable<DOMString[]>? asynciterableses;
 typedef object obj;
 typedef (short or [Extended] double) union;
 typedef (short or sequence < DOMString [ ] ? [ ] > ? or DOMString[]?[] or unsigned long long or unrestricted double) craziness;

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1085,7 +1085,7 @@ class NonAnyType(ComplexProduction):
 			self.async_iterable[0].define_markup(generator)
 			self.async_iterable[1].define_markup(generator)
 			generator.add_text(self._open_type)
-			self.type.define_markup(generator)
+			generator.add_type(self.type)  
 			generator.add_text(self._close_type)
 			generator.add_text(self.null)
 			return self

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -1085,7 +1085,7 @@ class NonAnyType(ComplexProduction):
 			self.async_iterable[0].define_markup(generator)
 			self.async_iterable[1].define_markup(generator)
 			generator.add_text(self._open_type)
-			generator.add_type(self.type)  
+			generator.add_type(self.type)
 			generator.add_text(self._close_type)
 			generator.add_text(self.null)
 			return self

--- a/widlparser/productions.py
+++ b/widlparser/productions.py
@@ -931,7 +931,8 @@ class NonAnyType(ComplexProduction):
 	Syntax:
 	PrimitiveType [TypeSuffix] | "ByteString" [TypeSuffix] | "DOMString" [TypeSuffix]
 	| "USVString" TypeSuffix | Identifier [TypeSuffix] | "sequence" "<" TypeWithExtendedAttributes ">" [Null]
-	| "object" [TypeSuffix] | "Error" TypeSuffix | "Promise" "<" Type ">" [Null] | BufferRelatedType [Null]
+	| "async" "iterable" "<" TypeWithExtendedAttributes ">" [Null] | "object" [TypeSuffix] | "Error" TypeSuffix
+	| "Promise" "<" Type ">" [Null] | BufferRelatedType [Null]
 	| "FrozenArray" "<" TypeWithExtendedAttributes ">" [Null] | "ObservableArray" "<" TypeWithExtendedAttributes ">" [Null]
 	| "record" "<" StringType "," TypeWithExtendedAttributes ">"
 	"""
@@ -945,6 +946,7 @@ class NonAnyType(ComplexProduction):
 	type: (PrimitiveType | TypeIdentifier | TypeWithExtendedAttributes | Type | Symbol)
 	type_name: (str | None)
 	sequence: (Symbol | None)
+	async_iterable: (tuple[Symbol, Symbol] | None)
 	promise: (Symbol | None)
 	record: (Symbol | None)
 	_open_type: (Symbol | None)
@@ -968,6 +970,13 @@ class NonAnyType(ComplexProduction):
 					if (Symbol.peek(tokens, '>')):
 						Symbol.peek(tokens, '?')
 						return tokens.pop_position(True)
+		elif (token and token.is_symbol('async')):
+			if (Symbol.peek(tokens, 'iterable')):
+				if (Symbol.peek(tokens, '<')):
+					if (TypeWithExtendedAttributes.peek(tokens)):
+						if (Symbol.peek(tokens, '>')):
+							Symbol.peek(tokens, '?')
+							return tokens.pop_position(True)
 		elif (token and token.is_symbol('Promise')):
 			if (Symbol.peek(tokens, '<')):
 				if (Type.peek(tokens)):
@@ -990,6 +999,7 @@ class NonAnyType(ComplexProduction):
 	def __init__(self, tokens: Tokenizer, parent: ComplexProduction) -> None:
 		super().__init__(tokens, parent)
 		self.sequence = None
+		self.async_iterable = None
 		self.promise = None
 		self.record = None
 		self._open_type = None
@@ -1009,6 +1019,12 @@ class NonAnyType(ComplexProduction):
 				self.suffix = TypeSuffix(tokens) if (TypeSuffix.peek(tokens)) else None
 			elif (token.is_symbol(('sequence', 'FrozenArray', 'ObservableArray'))):
 				self.sequence = Symbol(tokens)
+				self._open_type = Symbol(tokens, '<')
+				self.type = TypeWithExtendedAttributes(tokens, self)
+				self._close_type = Symbol(tokens, '>', False)
+				self.null = Symbol(tokens, '?', False) if (Symbol.peek(tokens, '?')) else None
+			elif (token.is_symbol('async')):
+				self.async_iterable = (Symbol(tokens), Symbol(tokens))
 				self._open_type = Symbol(tokens, '<')
 				self.type = TypeWithExtendedAttributes(tokens, self)
 				self._close_type = Symbol(tokens, '>', False)
@@ -1043,6 +1059,9 @@ class NonAnyType(ComplexProduction):
 		if (self.sequence):
 			output = str(self.sequence) + str(self._open_type) + str(self.type) + str(self._close_type)
 			return output + (str(self.null) if (self.null) else '')
+		if (self.async_iterable):
+			output = str(self.async_iterable[0]) + str(self.async_iterable[1]) + str(self._open_type) + str(self.type) + str(self._close_type)
+			return output + (str(self.null) if (self.null) else '')
 		if (self.promise):
 			output = str(self.promise) + str(self._open_type) + str(self.type) + str(self._close_type)
 			return output + (str(self.null) if (self.null) else '')
@@ -1059,6 +1078,14 @@ class NonAnyType(ComplexProduction):
 			self.sequence.define_markup(generator)
 			generator.add_text(self._open_type)
 			generator.add_type(self.type)
+			generator.add_text(self._close_type)
+			generator.add_text(self.null)
+			return self
+		if (self.async_iterable):
+			self.async_iterable[0].define_markup(generator)
+			self.async_iterable[1].define_markup(generator)
+			generator.add_text(self._open_type)
+			self.type.define_markup(generator)
 			generator.add_text(self._close_type)
 			generator.add_text(self.null)
 			return self


### PR DESCRIPTION
Ref https://github.com/whatwg/webidl/pull/1397

DO NOT LAND UNTIL SPEC CHANGE IS LANDED